### PR TITLE
Add KeywordAnalyzer with Aho-Corasick multi-pattern matching (P1-T3)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ protobuf>=5.29.0
 python-multipart>=0.0.18
 httpx>=0.28.0
 google-re2>=1.1
+pyahocorasick>=2.0.0
 ruff>=0.8.0
 pytest>=8.3.0
 pytest-asyncio>=0.25.0

--- a/server/detection/analyzers/__init__.py
+++ b/server/detection/analyzers/__init__.py
@@ -70,5 +70,19 @@ class BaseAnalyzer(ABC):
 
 
 from server.detection.analyzers.regex_analyzer import RegexAnalyzer, RegexPattern
+from server.detection.analyzers.keyword_analyzer import (
+    CaseMode,
+    KeywordAnalyzer,
+    KeywordDictionaryConfig,
+    ProximityRule,
+)
 
-__all__ = ["BaseAnalyzer", "RegexAnalyzer", "RegexPattern"]
+__all__ = [
+    "BaseAnalyzer",
+    "CaseMode",
+    "KeywordAnalyzer",
+    "KeywordDictionaryConfig",
+    "ProximityRule",
+    "RegexAnalyzer",
+    "RegexPattern",
+]

--- a/server/detection/analyzers/keyword_analyzer.py
+++ b/server/detection/analyzers/keyword_analyzer.py
@@ -1,0 +1,321 @@
+"""Keyword-based content analyzer using Aho-Corasick multi-pattern matching.
+
+Uses pyahocorasick for O(n + m) matching where n is text length and m is
+total matches — far more efficient than running each keyword separately.
+Supports case-sensitive/insensitive modes, whole-word matching, and
+proximity matching (two keywords within N words of each other).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+
+import ahocorasick
+
+from server.detection.analyzers import BaseAnalyzer
+from server.detection.models import (
+    ComponentType,
+    Match,
+    MessageComponent,
+    ParsedMessage,
+)
+
+logger = logging.getLogger(__name__)
+
+# Pre-compiled word boundary pattern
+_WORD_CHAR = re.compile(r"\w", re.UNICODE)
+
+
+class CaseMode(str, Enum):
+    """Case sensitivity mode for keyword matching."""
+
+    SENSITIVE = "sensitive"
+    INSENSITIVE = "insensitive"
+
+
+@dataclass
+class ProximityRule:
+    """Two keywords that must appear within N words of each other.
+
+    Attributes:
+        keyword_a: First keyword to find.
+        keyword_b: Second keyword to find.
+        max_distance: Maximum number of words between the two keywords.
+        case_mode: Case sensitivity for this rule.
+    """
+
+    keyword_a: str
+    keyword_b: str
+    max_distance: int
+    case_mode: CaseMode = CaseMode.INSENSITIVE
+
+
+@dataclass
+class KeywordDictionaryConfig:
+    """Configuration for a keyword dictionary.
+
+    Attributes:
+        name: Human-readable dictionary name (e.g., "PCI Keywords").
+        keywords: List of keywords to match.
+        case_mode: Case sensitivity for all keywords.
+        whole_word: If True, keywords must be bounded by non-word chars.
+        proximity_rules: Optional proximity rules for keyword pairs.
+        confidence: Confidence score for matches from this dictionary.
+    """
+
+    name: str
+    keywords: list[str]
+    case_mode: CaseMode = CaseMode.INSENSITIVE
+    whole_word: bool = True
+    proximity_rules: list[ProximityRule] = field(default_factory=list)
+    confidence: float = 1.0
+
+
+def _is_word_boundary(text: str, pos: int) -> bool:
+    """Check if position is at a word boundary.
+
+    A word boundary exists at position `pos` if the character at pos
+    is not a word character OR pos is at the start/end of the string.
+    """
+    if pos < 0 or pos >= len(text):
+        return True
+    return not _WORD_CHAR.match(text[pos])
+
+
+def _word_positions(text: str) -> list[tuple[int, int]]:
+    """Return (start, end) positions of all words in text.
+
+    Words are sequences of word characters (\\w+).
+    """
+    return [(m.start(), m.end()) for m in re.finditer(r"\w+", text, re.UNICODE)]
+
+
+class KeywordAnalyzer(BaseAnalyzer):
+    """Analyzer that detects keywords using Aho-Corasick automaton.
+
+    Builds an automaton from a keyword dictionary for efficient
+    multi-pattern matching. Supports:
+    - Case-sensitive and case-insensitive modes
+    - Whole-word matching (keyword bounded by non-word chars)
+    - Proximity matching (two keywords within N words)
+
+    Example:
+        >>> config = KeywordDictionaryConfig(
+        ...     name="PCI Terms",
+        ...     keywords=["credit card", "cvv", "expiration"],
+        ...     case_mode=CaseMode.INSENSITIVE,
+        ...     whole_word=True,
+        ... )
+        >>> analyzer = KeywordAnalyzer(name="pci_kw", dictionaries=[config])
+    """
+
+    def __init__(
+        self,
+        name: str,
+        dictionaries: list[KeywordDictionaryConfig],
+        target_components: list[ComponentType] | None = None,
+    ) -> None:
+        """Initialize with keyword dictionaries.
+
+        Args:
+            name: Unique analyzer name.
+            dictionaries: List of keyword dictionary configurations.
+            target_components: Component types to scan. None means all.
+        """
+        super().__init__(name=name, target_components=target_components)
+        self._dictionaries = dictionaries
+        self._automatons: list[tuple[KeywordDictionaryConfig, ahocorasick.Automaton]] = []
+
+        for d in dictionaries:
+            automaton = self._build_automaton(d)
+            self._automatons.append((d, automaton))
+            logger.debug(
+                "Built automaton for %r: %d keywords, case=%s, whole_word=%s",
+                d.name,
+                len(d.keywords),
+                d.case_mode.value,
+                d.whole_word,
+            )
+
+    @staticmethod
+    def _build_automaton(config: KeywordDictionaryConfig) -> ahocorasick.Automaton:
+        """Build an Aho-Corasick automaton from a dictionary config."""
+        automaton = ahocorasick.Automaton()
+
+        for keyword in config.keywords:
+            stored = keyword
+            if config.case_mode == CaseMode.INSENSITIVE:
+                key = keyword.lower()
+            else:
+                key = keyword
+            automaton.add_word(key, (stored, len(key)))
+
+        if len(automaton) > 0:
+            automaton.make_automaton()
+
+        return automaton
+
+    @property
+    def dictionary_count(self) -> int:
+        """Number of loaded dictionaries."""
+        return len(self._dictionaries)
+
+    @property
+    def total_keywords(self) -> int:
+        """Total keywords across all dictionaries."""
+        return sum(len(d.keywords) for d in self._dictionaries)
+
+    def analyze(self, message: ParsedMessage) -> list[Match]:
+        """Run keyword matching against targeted components.
+
+        Args:
+            message: The parsed message to analyze.
+
+        Returns:
+            List of Match objects for keyword hits and proximity matches.
+        """
+        matches: list[Match] = []
+        components = self.get_target_components(message)
+
+        for config, automaton in self._automatons:
+            for component in components:
+                # Standard keyword matches
+                if len(automaton) > 0:
+                    kw_matches = self._match_keywords(config, automaton, component)
+                    matches.extend(kw_matches)
+
+                # Proximity matches
+                if config.proximity_rules:
+                    prox_matches = self._match_proximity(
+                        config, component
+                    )
+                    matches.extend(prox_matches)
+
+        logger.debug(
+            "KeywordAnalyzer %r found %d matches in message %s",
+            self.name,
+            len(matches),
+            message.message_id,
+        )
+        return matches
+
+    def _match_keywords(
+        self,
+        config: KeywordDictionaryConfig,
+        automaton: ahocorasick.Automaton,
+        component: MessageComponent,
+    ) -> list[Match]:
+        """Find keyword matches in a single component."""
+        matches: list[Match] = []
+        text = component.content
+        search_text = (
+            text.lower()
+            if config.case_mode == CaseMode.INSENSITIVE
+            else text
+        )
+
+        for end_idx, (original_keyword, length) in automaton.iter(search_text):
+            start_idx = end_idx - length + 1
+
+            # Whole-word check
+            if config.whole_word:
+                if not _is_word_boundary(search_text, start_idx - 1):
+                    continue
+                if not _is_word_boundary(search_text, end_idx + 1):
+                    continue
+
+            matched_text = text[start_idx : end_idx + 1]
+
+            matches.append(
+                Match(
+                    analyzer_name=self.name,
+                    rule_name=f"{config.name}:{original_keyword}",
+                    component=component,
+                    matched_text=matched_text,
+                    start_offset=start_idx,
+                    end_offset=end_idx + 1,
+                    confidence=config.confidence,
+                    metadata={
+                        "dictionary": config.name,
+                        "keyword": original_keyword,
+                        "case_mode": config.case_mode.value,
+                        "whole_word": config.whole_word,
+                    },
+                )
+            )
+
+        return matches
+
+    def _match_proximity(
+        self,
+        config: KeywordDictionaryConfig,
+        component: MessageComponent,
+    ) -> list[Match]:
+        """Find proximity matches: two keywords within N words.
+
+        For each proximity rule, find all occurrences of keyword_a and
+        keyword_b, then check if any pair is within max_distance words.
+        """
+        matches: list[Match] = []
+        text = component.content
+
+        # Get word positions for distance calculation
+        word_spans = _word_positions(text)
+        if not word_spans:
+            return matches
+
+        # Build list of (word_index, word_text_lower)
+        words_lower = [
+            text[s:e].lower() for s, e in word_spans
+        ]
+
+        for rule in config.proximity_rules:
+            kw_a = rule.keyword_a.lower() if rule.case_mode == CaseMode.INSENSITIVE else rule.keyword_a
+            kw_b = rule.keyword_b.lower() if rule.case_mode == CaseMode.INSENSITIVE else rule.keyword_b
+
+            # Find word indices where each keyword appears
+            a_indices = [
+                i for i, w in enumerate(words_lower) if w == kw_a
+            ]
+            b_indices = [
+                i for i, w in enumerate(words_lower) if w == kw_b
+            ]
+
+            # Check all pairs for proximity
+            for ai in a_indices:
+                for bi in b_indices:
+                    if ai == bi:
+                        continue
+                    distance = abs(ai - bi) - 1  # words between them
+                    if distance <= rule.max_distance:
+                        # Build match spanning from first to last keyword
+                        first_idx = min(ai, bi)
+                        last_idx = max(ai, bi)
+                        start_offset = word_spans[first_idx][0]
+                        end_offset = word_spans[last_idx][1]
+                        matched_text = text[start_offset:end_offset]
+
+                        matches.append(
+                            Match(
+                                analyzer_name=self.name,
+                                rule_name=f"{config.name}:proximity({rule.keyword_a}~{rule.keyword_b})",
+                                component=component,
+                                matched_text=matched_text,
+                                start_offset=start_offset,
+                                end_offset=end_offset,
+                                confidence=config.confidence,
+                                metadata={
+                                    "dictionary": config.name,
+                                    "proximity_rule": True,
+                                    "keyword_a": rule.keyword_a,
+                                    "keyword_b": rule.keyword_b,
+                                    "distance": distance,
+                                    "max_distance": rule.max_distance,
+                                },
+                            )
+                        )
+
+        return matches

--- a/tests/detection/test_keyword_analyzer.py
+++ b/tests/detection/test_keyword_analyzer.py
@@ -1,0 +1,787 @@
+"""Tests for the KeywordAnalyzer (P1-T3).
+
+Covers: Aho-Corasick multi-keyword matching, case modes, whole-word,
+proximity matching, component targeting, 50-keyword dictionary, and
+adversarial edge cases.
+"""
+
+import pytest
+
+from server.detection.models import ComponentType, ParsedMessage
+from server.detection.analyzers.keyword_analyzer import (
+    CaseMode,
+    KeywordAnalyzer,
+    KeywordDictionaryConfig,
+    ProximityRule,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _make_message(**components: str) -> ParsedMessage:
+    """Build a ParsedMessage from keyword component types and content."""
+    msg = ParsedMessage()
+    type_map = {
+        "envelope": ComponentType.ENVELOPE,
+        "subject": ComponentType.SUBJECT,
+        "body": ComponentType.BODY,
+        "attachment": ComponentType.ATTACHMENT,
+        "generic": ComponentType.GENERIC,
+    }
+    for key, content in components.items():
+        msg.add_component(type_map[key], content)
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# 50-keyword dictionary for acceptance test
+# ---------------------------------------------------------------------------
+
+FINANCIAL_KEYWORDS = [
+    "credit card", "debit card", "bank account", "routing number",
+    "wire transfer", "account number", "social security", "tax id",
+    "taxpayer", "w-2", "1099", "ach transfer", "swift code",
+    "iban", "cvv", "cvc", "expiration date", "cardholder",
+    "pin number", "atm", "checking account", "savings account",
+    "loan", "mortgage", "investment", "portfolio", "dividend",
+    "securities", "stock option", "earnings", "revenue", "profit",
+    "loss statement", "balance sheet", "cash flow", "audit",
+    "compliance", "gdpr", "pci-dss", "hipaa", "sox",
+    "encryption key", "private key", "api key", "access token",
+    "bearer token", "password", "credential", "authentication",
+    "authorization",
+]
+assert len(FINANCIAL_KEYWORDS) == 50
+
+
+# ---------------------------------------------------------------------------
+# Basic keyword matching
+# ---------------------------------------------------------------------------
+
+
+class TestBasicMatching:
+    """Core keyword matching functionality."""
+
+    def test_single_keyword_match(self):
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["password"]
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="Please reset your password immediately")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 1
+        assert matches[0].matched_text.lower() == "password"
+        assert matches[0].metadata["keyword"] == "password"
+
+    def test_multi_word_keyword(self):
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["credit card"]
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="Enter your credit card number below")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 1
+        assert matches[0].matched_text.lower() == "credit card"
+
+    def test_multiple_keywords_in_text(self):
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["password", "username", "credential"]
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(
+            body="Your username and password are your credential"
+        )
+        matches = analyzer.analyze(msg)
+
+        found = {m.metadata["keyword"] for m in matches}
+        assert found == {"password", "username", "credential"}
+
+    def test_no_match(self):
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["classified"]
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="Nothing sensitive here at all")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 0
+
+    def test_repeated_keyword(self):
+        """Same keyword appearing multiple times is reported each time."""
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["secret"]
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="secret one, secret two, secret three")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 3
+
+    def test_dictionary_count(self):
+        analyzer = KeywordAnalyzer(
+            name="kw",
+            dictionaries=[
+                KeywordDictionaryConfig(name="a", keywords=["x"]),
+                KeywordDictionaryConfig(name="b", keywords=["y"]),
+            ],
+        )
+        assert analyzer.dictionary_count == 2
+
+    def test_total_keywords(self):
+        analyzer = KeywordAnalyzer(
+            name="kw",
+            dictionaries=[
+                KeywordDictionaryConfig(name="a", keywords=["x", "y"]),
+                KeywordDictionaryConfig(name="b", keywords=["z"]),
+            ],
+        )
+        assert analyzer.total_keywords == 3
+
+
+# ---------------------------------------------------------------------------
+# Case mode tests
+# ---------------------------------------------------------------------------
+
+
+class TestCaseModes:
+    """Case-sensitive and case-insensitive matching."""
+
+    def test_case_insensitive_default(self):
+        """Default is case-insensitive."""
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["password"]
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="PASSWORD reset required")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 1
+        assert matches[0].matched_text == "PASSWORD"
+
+    def test_case_insensitive_mixed(self):
+        config = KeywordDictionaryConfig(
+            name="test",
+            keywords=["credit card"],
+            case_mode=CaseMode.INSENSITIVE,
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="Your Credit Card is compromised")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 1
+        assert matches[0].matched_text == "Credit Card"
+
+    def test_case_sensitive_exact_match(self):
+        config = KeywordDictionaryConfig(
+            name="test",
+            keywords=["CONFIDENTIAL"],
+            case_mode=CaseMode.SENSITIVE,
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="This is CONFIDENTIAL data")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 1
+
+    def test_case_sensitive_no_match(self):
+        config = KeywordDictionaryConfig(
+            name="test",
+            keywords=["CONFIDENTIAL"],
+            case_mode=CaseMode.SENSITIVE,
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="This is confidential data")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 0
+
+    def test_case_metadata_recorded(self):
+        config = KeywordDictionaryConfig(
+            name="test",
+            keywords=["secret"],
+            case_mode=CaseMode.INSENSITIVE,
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="SECRET document")
+        matches = analyzer.analyze(msg)
+
+        assert matches[0].metadata["case_mode"] == "insensitive"
+
+
+# ---------------------------------------------------------------------------
+# Whole-word matching
+# ---------------------------------------------------------------------------
+
+
+class TestWholeWord:
+    """Whole-word boundary matching."""
+
+    def test_whole_word_match(self):
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["pin"], whole_word=True
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="Enter your pin to continue")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 1
+
+    def test_whole_word_rejects_substring(self):
+        """'pin' should NOT match inside 'spinning'."""
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["pin"], whole_word=True
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="The spinning wheel turned")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 0
+
+    def test_whole_word_rejects_prefix(self):
+        """'pin' should NOT match 'pinpoint'."""
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["pin"], whole_word=True
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="Pinpoint the location")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 0
+
+    def test_whole_word_rejects_suffix(self):
+        """'key' should NOT match 'turkey'."""
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["key"], whole_word=True
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="I ate turkey for dinner")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 0
+
+    def test_whole_word_at_boundaries(self):
+        """Keyword at start/end of string is still a whole word."""
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["secret"], whole_word=True
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+
+        msg1 = _make_message(body="secret at start")
+        assert len(analyzer.analyze(msg1)) == 1
+
+        msg2 = _make_message(body="at the end secret")
+        assert len(analyzer.analyze(msg2)) == 1
+
+    def test_whole_word_with_punctuation(self):
+        """Keyword next to punctuation is a whole-word match."""
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["password"], whole_word=True
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="Your password, username, and pin.")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 1
+
+    def test_no_whole_word_matches_substring(self):
+        """With whole_word=False, 'pin' matches inside 'spinning'."""
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["pin"], whole_word=False
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="The spinning wheel turned")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 1
+
+
+# ---------------------------------------------------------------------------
+# Proximity matching
+# ---------------------------------------------------------------------------
+
+
+class TestProximity:
+    """Proximity matching: two keywords within N words."""
+
+    def test_credit_within_3_words_of_card(self):
+        """'credit' within 3 words of 'card' should match."""
+        config = KeywordDictionaryConfig(
+            name="pci",
+            keywords=[],
+            proximity_rules=[
+                ProximityRule(
+                    keyword_a="credit",
+                    keyword_b="card",
+                    max_distance=3,
+                )
+            ],
+        )
+        analyzer = KeywordAnalyzer(name="prox", dictionaries=[config])
+        msg = _make_message(body="Please enter your credit card number")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 1
+        assert matches[0].metadata["proximity_rule"] is True
+        assert matches[0].metadata["keyword_a"] == "credit"
+        assert matches[0].metadata["keyword_b"] == "card"
+        assert matches[0].metadata["distance"] <= 3
+
+    def test_credit_not_within_3_words_of_union(self):
+        """'credit' NOT within 3 words of 'union' when far apart."""
+        config = KeywordDictionaryConfig(
+            name="pci",
+            keywords=[],
+            proximity_rules=[
+                ProximityRule(
+                    keyword_a="credit",
+                    keyword_b="union",
+                    max_distance=3,
+                )
+            ],
+        )
+        analyzer = KeywordAnalyzer(name="prox", dictionaries=[config])
+        msg = _make_message(
+            body="The credit was applied to your account at the local union office"
+        )
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 0
+
+    def test_proximity_exact_distance(self):
+        """Keywords exactly max_distance words apart should match."""
+        config = KeywordDictionaryConfig(
+            name="test",
+            keywords=[],
+            proximity_rules=[
+                ProximityRule(
+                    keyword_a="social",
+                    keyword_b="number",
+                    max_distance=2,
+                )
+            ],
+        )
+        analyzer = KeywordAnalyzer(name="prox", dictionaries=[config])
+        # "social" [security] [card] "number" — 2 words between
+        msg = _make_message(body="social security card number")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 1
+        assert matches[0].metadata["distance"] == 2
+
+    def test_proximity_one_too_far(self):
+        """Keywords one word beyond max_distance should NOT match."""
+        config = KeywordDictionaryConfig(
+            name="test",
+            keywords=[],
+            proximity_rules=[
+                ProximityRule(
+                    keyword_a="social",
+                    keyword_b="number",
+                    max_distance=1,
+                )
+            ],
+        )
+        analyzer = KeywordAnalyzer(name="prox", dictionaries=[config])
+        # "social" [security] [card] "number" — 2 words between, max is 1
+        msg = _make_message(body="social security card number")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 0
+
+    def test_proximity_adjacent_words(self):
+        """Adjacent keywords have distance 0."""
+        config = KeywordDictionaryConfig(
+            name="test",
+            keywords=[],
+            proximity_rules=[
+                ProximityRule(
+                    keyword_a="bank",
+                    keyword_b="account",
+                    max_distance=0,
+                )
+            ],
+        )
+        analyzer = KeywordAnalyzer(name="prox", dictionaries=[config])
+        msg = _make_message(body="Your bank account is secure")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 1
+        assert matches[0].metadata["distance"] == 0
+
+    def test_proximity_reversed_order(self):
+        """Proximity matches regardless of keyword order in text."""
+        config = KeywordDictionaryConfig(
+            name="test",
+            keywords=[],
+            proximity_rules=[
+                ProximityRule(
+                    keyword_a="card",
+                    keyword_b="credit",
+                    max_distance=3,
+                )
+            ],
+        )
+        analyzer = KeywordAnalyzer(name="prox", dictionaries=[config])
+        msg = _make_message(body="Enter your credit card details")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 1
+
+    def test_proximity_case_insensitive(self):
+        """Proximity matching respects case mode."""
+        config = KeywordDictionaryConfig(
+            name="test",
+            keywords=[],
+            proximity_rules=[
+                ProximityRule(
+                    keyword_a="CREDIT",
+                    keyword_b="CARD",
+                    max_distance=3,
+                    case_mode=CaseMode.INSENSITIVE,
+                )
+            ],
+        )
+        analyzer = KeywordAnalyzer(name="prox", dictionaries=[config])
+        msg = _make_message(body="Enter your Credit Card number")
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 1
+
+    def test_proximity_with_keywords_combined(self):
+        """Proximity rules work alongside standard keyword matches."""
+        config = KeywordDictionaryConfig(
+            name="pci",
+            keywords=["cvv", "expiration"],
+            proximity_rules=[
+                ProximityRule(
+                    keyword_a="credit",
+                    keyword_b="card",
+                    max_distance=3,
+                )
+            ],
+        )
+        analyzer = KeywordAnalyzer(name="combo", dictionaries=[config])
+        msg = _make_message(
+            body="Enter credit card number, cvv, and expiration date"
+        )
+        matches = analyzer.analyze(msg)
+
+        rule_names = {m.rule_name for m in matches}
+        assert any("cvv" in r for r in rule_names)
+        assert any("expiration" in r for r in rule_names)
+        assert any("proximity" in r for r in rule_names)
+
+
+# ---------------------------------------------------------------------------
+# 50-keyword dictionary acceptance test
+# ---------------------------------------------------------------------------
+
+
+class TestFiftyKeywordDictionary:
+    """Acceptance test: 50-keyword dictionary matches in test document."""
+
+    def test_50_keyword_dictionary(self):
+        config = KeywordDictionaryConfig(
+            name="financial",
+            keywords=FINANCIAL_KEYWORDS,
+            case_mode=CaseMode.INSENSITIVE,
+            whole_word=True,
+        )
+        analyzer = KeywordAnalyzer(name="fin50", dictionaries=[config])
+
+        document = """
+        INTERNAL MEMO - CONFIDENTIAL
+
+        Subject: Q4 Financial Audit and Compliance Review
+
+        The audit team has completed the SOX compliance review for fiscal year.
+        Our portfolio shows strong revenue growth with increased profit margins.
+        The balance sheet and cash flow statements are attached. The loss statement
+        for Q3 has been revised. Investment returns on securities and stock option
+        grants exceeded projections. Dividend payments are scheduled for next month.
+        Earnings call is on January 15th.
+
+        SECURITY ITEMS:
+        - All encryption key rotation completed
+        - Private key storage migrated to HSM
+        - API key management moved to vault
+        - Access token and bearer token TTLs reduced to 1 hour
+        - Authentication and authorization review complete
+
+        PCI-DSS FINDINGS:
+        - Credit card data found in legacy database
+        - Debit card processing needs TLS 1.3 upgrade
+        - CVV and CVC storage violations in backup system
+        - Cardholder data environment needs segmentation
+        - PIN number handling meets requirements
+        - Expiration date stored in plaintext — must encrypt
+
+        BANKING:
+        - Bank account reconciliation completed
+        - Checking account and savings account audited
+        - Routing number validation implemented
+        - Wire transfer limits enforced
+        - ACH transfer monitoring active
+        - SWIFT code database updated
+        - IBAN validation added for EU transfers
+        - Account number masking in logs verified
+
+        PERSONAL DATA:
+        - Social security number detection deployed
+        - Tax ID validation rules updated
+        - Taxpayer records encrypted at rest
+        - W-2 and 1099 forms secured
+        - ATM transaction logs reviewed
+
+        REGULATORY:
+        - GDPR data subject requests processed
+        - HIPAA audit trail verified
+        - Credential rotation policy enforced
+        - Password complexity requirements updated
+        - Loan and mortgage data classified
+        """
+
+        msg = _make_message(body=document)
+        matches = analyzer.analyze(msg)
+
+        # Collect unique keywords that matched
+        matched_keywords = {m.metadata["keyword"] for m in matches}
+
+        # Should match a substantial portion of the 50 keywords
+        assert len(matched_keywords) >= 40, (
+            f"Only {len(matched_keywords)}/50 keywords matched: "
+            f"missing {set(FINANCIAL_KEYWORDS) - matched_keywords}"
+        )
+
+    def test_50_keyword_performance(self):
+        """50-keyword dictionary scans 100KB document in reasonable time."""
+        import time
+
+        config = KeywordDictionaryConfig(
+            name="financial",
+            keywords=FINANCIAL_KEYWORDS,
+        )
+        analyzer = KeywordAnalyzer(name="perf", dictionaries=[config])
+
+        # 100KB document
+        chunk = "This document contains a password and a credit card and an api key. "
+        document = chunk * (100_000 // len(chunk))
+        msg = _make_message(body=document)
+
+        start = time.perf_counter()
+        matches = analyzer.analyze(msg)
+        elapsed = time.perf_counter() - start
+
+        assert len(matches) > 0
+        assert elapsed < 2.0, f"50-keyword scan of 100KB took {elapsed:.2f}s"
+
+
+# ---------------------------------------------------------------------------
+# Component targeting
+# ---------------------------------------------------------------------------
+
+
+class TestComponentTargeting:
+    """Component targeting with keyword analyzer."""
+
+    def test_body_only(self):
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["password"]
+        )
+        analyzer = KeywordAnalyzer(
+            name="kw",
+            dictionaries=[config],
+            target_components=[ComponentType.BODY],
+        )
+        msg = _make_message(
+            subject="password reset",
+            body="Enter your password",
+            attachment="password in file",
+        )
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 1
+        assert matches[0].component.component_type == ComponentType.BODY
+
+    def test_attachment_only(self):
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["confidential"]
+        )
+        analyzer = KeywordAnalyzer(
+            name="kw",
+            dictionaries=[config],
+            target_components=[ComponentType.ATTACHMENT],
+        )
+        msg = _make_message(
+            body="This is confidential",
+            attachment="confidential document attached",
+        )
+        matches = analyzer.analyze(msg)
+
+        assert len(matches) == 1
+        assert matches[0].component.component_type == ComponentType.ATTACHMENT
+
+
+# ---------------------------------------------------------------------------
+# Adversarial tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarial:
+    """Adversarial inputs and edge cases."""
+
+    def test_empty_content(self):
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["secret"]
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="")
+        matches = analyzer.analyze(msg)
+        assert len(matches) == 0
+
+    def test_empty_keywords_list(self):
+        config = KeywordDictionaryConfig(
+            name="test", keywords=[]
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="some text")
+        matches = analyzer.analyze(msg)
+        assert len(matches) == 0
+
+    def test_null_bytes(self):
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["secret"]
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="the secret\x00hidden data")
+        matches = analyzer.analyze(msg)
+        assert len(matches) == 1
+
+    def test_unicode_keywords(self):
+        """Unicode keywords match correctly."""
+        config = KeywordDictionaryConfig(
+            name="test",
+            keywords=["données personnelles", "日本語"],
+            case_mode=CaseMode.SENSITIVE,
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        # Space after 日本語 so whole-word boundary is satisfied
+        msg = _make_message(body="Les données personnelles sont protégées. 日本語 テスト")
+        matches = analyzer.analyze(msg)
+        assert len(matches) == 2
+
+    def test_overlapping_keywords(self):
+        """Keywords that overlap in text are all reported."""
+        config = KeywordDictionaryConfig(
+            name="test",
+            keywords=["credit", "credit card"],
+            whole_word=False,
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="your credit card")
+        matches = analyzer.analyze(msg)
+
+        keywords = {m.metadata["keyword"] for m in matches}
+        assert "credit" in keywords
+        assert "credit card" in keywords
+
+    def test_very_long_keyword(self):
+        """A very long keyword still matches."""
+        long_kw = "a" * 1000
+        config = KeywordDictionaryConfig(
+            name="test", keywords=[long_kw], whole_word=False
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="prefix " + long_kw + " suffix")
+        matches = analyzer.analyze(msg)
+        assert len(matches) == 1
+
+    def test_special_regex_chars_in_keyword(self):
+        """Keywords with regex metacharacters are treated as literal."""
+        config = KeywordDictionaryConfig(
+            name="test",
+            keywords=["price: $100.00", "file (*.txt)"],
+            whole_word=False,
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+        msg = _make_message(body="The price: $100.00 for file (*.txt)")
+        matches = analyzer.analyze(msg)
+        assert len(matches) == 2
+
+    def test_large_content_1mb(self):
+        """1MB content scans without issues."""
+        import time
+
+        config = KeywordDictionaryConfig(
+            name="test", keywords=["needle"]
+        )
+        analyzer = KeywordAnalyzer(name="kw", dictionaries=[config])
+
+        filler = "x" * 500_000
+        content = filler + " needle " + filler
+        msg = _make_message(body=content)
+
+        start = time.perf_counter()
+        matches = analyzer.analyze(msg)
+        elapsed = time.perf_counter() - start
+
+        assert len(matches) == 1
+        assert elapsed < 2.0
+
+    def test_proximity_no_keywords_present(self):
+        """Proximity rule with neither keyword present produces no matches."""
+        config = KeywordDictionaryConfig(
+            name="test",
+            keywords=[],
+            proximity_rules=[
+                ProximityRule(keyword_a="foo", keyword_b="bar", max_distance=5)
+            ],
+        )
+        analyzer = KeywordAnalyzer(name="prox", dictionaries=[config])
+        msg = _make_message(body="nothing relevant here")
+        matches = analyzer.analyze(msg)
+        assert len(matches) == 0
+
+    def test_proximity_only_one_keyword_present(self):
+        """Proximity rule with only one keyword present produces no matches."""
+        config = KeywordDictionaryConfig(
+            name="test",
+            keywords=[],
+            proximity_rules=[
+                ProximityRule(keyword_a="credit", keyword_b="card", max_distance=3)
+            ],
+        )
+        analyzer = KeywordAnalyzer(name="prox", dictionaries=[config])
+        msg = _make_message(body="We accept credit for the purchase")
+        matches = analyzer.analyze(msg)
+        assert len(matches) == 0
+
+
+# ---------------------------------------------------------------------------
+# Engine integration
+# ---------------------------------------------------------------------------
+
+
+class TestEngineIntegration:
+    """Verify KeywordAnalyzer works within the DetectionEngine."""
+
+    def test_engine_with_keyword_analyzer(self):
+        from server.detection.engine import DetectionEngine
+
+        config = KeywordDictionaryConfig(
+            name="sensitive",
+            keywords=["password", "secret"],
+        )
+        engine = DetectionEngine()
+        engine.register(KeywordAnalyzer(name="kw", dictionaries=[config]))
+
+        msg = _make_message(body="The password is secret")
+        result = engine.detect(msg)
+
+        assert result.match_count == 2
+        assert len(result.errors) == 0


### PR DESCRIPTION
## Summary
- **KeywordAnalyzer** using pyahocorasick for O(n+m) Aho-Corasick multi-keyword matching
- **Case modes**: case-sensitive and case-insensitive (default) matching
- **Whole-word matching**: keywords bounded by non-word characters (rejects substrings like "pin" in "spinning")
- **Proximity matching**: two keywords within N words of each other (e.g., "credit" within 3 words of "card")
- `KeywordDictionaryConfig`, `ProximityRule`, `CaseMode` config dataclasses
- Added `pyahocorasick>=2.0.0` to requirements.txt

## Tests — 42 passing
- **Basic** (7): single/multi-word keywords, repeated matches, no match, dictionary counts
- **Case modes** (5): insensitive default, mixed case, sensitive exact/no match
- **Whole-word** (7): rejects substring/prefix/suffix, boundary positions, punctuation, opt-out
- **Proximity** (8): "credit"↔"card" within 3 ✓, "credit"↔"union" beyond 3 ✗, exact distance, adjacent, reversed order, case-insensitive, combined with keywords
- **50-keyword dictionary** (2): acceptance test with financial document, 100KB performance
- **Component targeting** (2): body-only, attachment-only
- **Adversarial** (9): empty content/keywords, null bytes, Unicode, overlapping keywords, 1000-char keyword, regex metacharacters, 1MB content, proximity edge cases
- **Engine integration** (1): works within DetectionEngine

## Test plan
- [x] `python -m pytest tests/detection/test_keyword_analyzer.py -v` — 42/42 pass
- [x] 50-keyword dictionary matches 40+ keywords in test document
- [x] Proximity: "credit" within 3 words of "card" matches, "credit" within 3 words of "union" does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)