### PR TITLE
Add PolicyEvaluator with Symantec 16.0-style policy logic (P1-T8)

### DIFF
--- a/server/detection/policy_evaluator.py
+++ b/server/detection/policy_evaluator.py
@@ -1,0 +1,612 @@
+"""Policy evaluator — Symantec 16.0-style policy evaluation engine.
+
+Implements compound rules (AND), multi-rule OR, detection+group AND,
+exception evaluation (entire message then MCO), and severity calculation
+with match count thresholds.
+
+Policy structure:
+  Policy
+    ├── detection_rules: list[DetectionRule]  (OR logic between rules)
+    │     └── conditions: list[RuleCondition]  (AND logic within a rule)
+    ├── groups: list[SenderRecipientGroup]     (AND with detection)
+    ├── exceptions: list[PolicyException]
+    └── severity_levels: list[SeverityLevel]
+
+Evaluation flow:
+  1. Run detection engine → DetectionResult
+  2. Evaluate detection rules (OR across rules, AND within conditions)
+  3. Apply group constraints (AND with detection)
+  4. Evaluate exceptions (entire-message first, then MCO per-component)
+  5. Calculate severity from remaining match count
+  6. Build PolicyViolation result
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable
+
+from server.detection.models import (
+    ComponentType,
+    DetectionResult,
+    Match,
+    ParsedMessage,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class Severity(str, Enum):
+    """Incident severity levels."""
+
+    INFO = "info"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class ConditionOperator(str, Enum):
+    """Operators for rule conditions."""
+
+    MATCHES = "matches"           # analyzer produced matches
+    NOT_MATCHES = "not_matches"   # analyzer produced NO matches
+    COUNT_GTE = "count_gte"       # match count >= threshold
+    COUNT_LTE = "count_lte"       # match count <= threshold
+
+
+class ExceptionScope(str, Enum):
+    """How an exception applies."""
+
+    ENTIRE_MESSAGE = "entire_message"   # Exclude entire message
+    COMPONENT = "component"             # MCO: remove matched component only
+
+
+class GroupMatchMode(str, Enum):
+    """How to match sender/recipient against a group."""
+
+    EXACT = "exact"
+    DOMAIN = "domain"
+    REGEX = "regex"
+
+
+# ---------------------------------------------------------------------------
+# Data classes — policy structure
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RuleCondition:
+    """A single condition within a detection rule.
+
+    A condition checks whether a specific analyzer produced matches
+    (or a match count threshold).
+
+    Attributes:
+        analyzer_name: Name of the analyzer whose matches to check.
+        operator: How to evaluate the matches.
+        threshold: For count operators, the comparison value.
+        component_types: Optional list to restrict which components
+            the condition checks. None means all.
+    """
+
+    analyzer_name: str
+    operator: ConditionOperator = ConditionOperator.MATCHES
+    threshold: int = 0
+    component_types: list[ComponentType] | None = None
+
+    def evaluate(self, detection: DetectionResult) -> bool:
+        """Evaluate this condition against a detection result."""
+        matches = detection.matches_for_analyzer(self.analyzer_name)
+
+        # Filter by component types if specified
+        if self.component_types:
+            ct_set = set(self.component_types)
+            matches = [
+                m for m in matches
+                if m.component.component_type in ct_set
+            ]
+
+        count = len(matches)
+
+        if self.operator == ConditionOperator.MATCHES:
+            return count > 0
+        elif self.operator == ConditionOperator.NOT_MATCHES:
+            return count == 0
+        elif self.operator == ConditionOperator.COUNT_GTE:
+            return count >= self.threshold
+        elif self.operator == ConditionOperator.COUNT_LTE:
+            return count <= self.threshold
+
+        return False
+
+
+@dataclass
+class DetectionRule:
+    """A detection rule composed of one or more conditions (AND logic).
+
+    All conditions must be satisfied for the rule to match.
+    Multiple rules within a policy use OR logic.
+
+    Attributes:
+        name: Unique name for this rule.
+        conditions: Conditions that must ALL be true.
+    """
+
+    name: str
+    conditions: list[RuleCondition] = field(default_factory=list)
+
+    def evaluate(self, detection: DetectionResult) -> bool:
+        """Evaluate: all conditions must match (AND)."""
+        if not self.conditions:
+            return False
+        return all(c.evaluate(detection) for c in self.conditions)
+
+    def matched_analyzers(self, detection: DetectionResult) -> set[str]:
+        """Return analyzer names that contributed matches for true conditions."""
+        names = set()
+        for cond in self.conditions:
+            if cond.evaluate(detection):
+                names.add(cond.analyzer_name)
+        return names
+
+
+@dataclass
+class SenderRecipientGroup:
+    """A group of senders or recipients for group AND logic.
+
+    Attributes:
+        name: Group name (e.g., "Executive Team").
+        members: List of member identifiers (emails, domains, patterns).
+        match_mode: How to compare message metadata against members.
+        field: Which metadata field to check (e.g., "sender", "recipients").
+    """
+
+    name: str
+    members: list[str] = field(default_factory=list)
+    match_mode: GroupMatchMode = GroupMatchMode.EXACT
+    field: str = "sender"  # "sender" or "recipients"
+
+    def matches_message(self, message: ParsedMessage) -> bool:
+        """Check if the message matches this group."""
+        value = message.metadata.get(self.field, "")
+
+        # For recipients, check if ANY recipient matches
+        if isinstance(value, list):
+            return any(self._matches_value(v) for v in value)
+
+        return self._matches_value(str(value))
+
+    def _matches_value(self, value: str) -> bool:
+        """Check if a single value matches any member."""
+        value_lower = value.lower()
+
+        for member in self.members:
+            member_lower = member.lower()
+
+            if self.match_mode == GroupMatchMode.EXACT:
+                if value_lower == member_lower:
+                    return True
+            elif self.match_mode == GroupMatchMode.DOMAIN:
+                # Extract domain from email
+                if "@" in value_lower:
+                    domain = value_lower.split("@", 1)[1]
+                    if domain == member_lower or domain.endswith(
+                        "." + member_lower
+                    ):
+                        return True
+                elif value_lower == member_lower:
+                    return True
+            elif self.match_mode == GroupMatchMode.REGEX:
+                if re.search(member, value, re.IGNORECASE):
+                    return True
+
+        return False
+
+
+@dataclass
+class PolicyException:
+    """An exception that can exclude matches from policy evaluation.
+
+    Entire-message exceptions prevent any incident. MCO (matched component
+    only) exceptions remove only the matches from matching components.
+
+    Attributes:
+        name: Exception name.
+        scope: ENTIRE_MESSAGE or COMPONENT (MCO).
+        condition: A callable that takes (message, detection) and returns True
+            if the exception applies. For declarative configs, use the
+            factory methods.
+        groups: Optional sender/recipient groups for exception matching.
+        analyzer_names: For MCO, which analyzer's matches to exclude.
+    """
+
+    name: str
+    scope: ExceptionScope = ExceptionScope.ENTIRE_MESSAGE
+    groups: list[SenderRecipientGroup] = field(default_factory=list)
+    analyzer_names: list[str] | None = None
+    component_types: list[ComponentType] | None = None
+    # Custom condition function: (message, detection) → bool
+    condition: Callable[[ParsedMessage, DetectionResult], bool] | None = None
+
+    def applies(
+        self, message: ParsedMessage, detection: DetectionResult
+    ) -> bool:
+        """Check if this exception applies to the message."""
+        # Custom condition takes priority
+        if self.condition is not None:
+            return self.condition(message, detection)
+
+        # Group-based exception: any group matches → exception applies
+        if self.groups:
+            return any(g.matches_message(message) for g in self.groups)
+
+        return False
+
+    def filter_matches(self, matches: list[Match]) -> list[Match]:
+        """For MCO scope, remove matches that this exception covers.
+
+        Returns the filtered match list (matches NOT covered by exception).
+        """
+        if self.scope == ExceptionScope.ENTIRE_MESSAGE:
+            # Entire message exception removes ALL matches
+            return []
+
+        # MCO: filter by analyzer names and/or component types
+        result = []
+        for match in matches:
+            excluded = True
+
+            if self.analyzer_names:
+                if match.analyzer_name not in self.analyzer_names:
+                    excluded = False
+
+            if excluded and self.component_types:
+                if match.component.component_type not in self.component_types:
+                    excluded = False
+
+            if not excluded:
+                result.append(match)
+
+        return result
+
+
+@dataclass
+class SeverityLevel:
+    """A severity tier based on match count thresholds.
+
+    Attributes:
+        severity: The severity level.
+        min_matches: Minimum match count to trigger this level.
+    """
+
+    severity: Severity
+    min_matches: int
+
+
+@dataclass
+class Policy:
+    """A DLP policy with detection rules, groups, exceptions, and severity.
+
+    Evaluation flow:
+    1. Detection rules are OR'd — any rule matching triggers the policy.
+    2. Groups are AND'd with detection — sender/recipient must match.
+    3. Exceptions are evaluated: entire-message first, then MCO.
+    4. Severity is calculated from remaining match count.
+
+    Attributes:
+        name: Policy name.
+        description: Policy description.
+        detection_rules: Rules to evaluate (OR logic between rules).
+        groups: Sender/recipient constraints (AND with detection).
+        exceptions: Exceptions to exclude matches/messages.
+        severity_levels: Sorted by min_matches descending for tier lookup.
+        default_severity: Severity when no tier matches.
+        enabled: Whether this policy is active.
+    """
+
+    name: str
+    description: str = ""
+    detection_rules: list[DetectionRule] = field(default_factory=list)
+    groups: list[SenderRecipientGroup] = field(default_factory=list)
+    exceptions: list[PolicyException] = field(default_factory=list)
+    severity_levels: list[SeverityLevel] = field(default_factory=list)
+    default_severity: Severity = Severity.LOW
+    enabled: bool = True
+
+
+@dataclass
+class PolicyViolation:
+    """Result of evaluating a single policy against a message.
+
+    Attributes:
+        policy_name: Name of the violated policy.
+        triggered: Whether the policy was violated.
+        severity: Calculated severity level.
+        matched_rules: Names of rules that matched.
+        matches: Remaining matches after exception filtering.
+        match_count: Number of remaining matches.
+        exceptions_applied: Names of exceptions that were applied.
+        errors: Any errors during evaluation.
+    """
+
+    policy_name: str
+    triggered: bool = False
+    severity: Severity = Severity.LOW
+    matched_rules: list[str] = field(default_factory=list)
+    matches: list[Match] = field(default_factory=list)
+    match_count: int = 0
+    exceptions_applied: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class EvaluationResult:
+    """Result of evaluating all policies against a message.
+
+    Attributes:
+        message_id: ID of the evaluated message.
+        violations: List of policy violations.
+        has_violations: Whether any policy was violated.
+        highest_severity: The highest severity across all violations.
+    """
+
+    message_id: str
+    violations: list[PolicyViolation] = field(default_factory=list)
+
+    @property
+    def has_violations(self) -> bool:
+        return any(v.triggered for v in self.violations)
+
+    @property
+    def highest_severity(self) -> Severity | None:
+        """Return the highest severity across all triggered violations."""
+        severity_order = [
+            Severity.INFO,
+            Severity.LOW,
+            Severity.MEDIUM,
+            Severity.HIGH,
+            Severity.CRITICAL,
+        ]
+        triggered = [v for v in self.violations if v.triggered]
+        if not triggered:
+            return None
+        return max(triggered, key=lambda v: severity_order.index(v.severity)).severity
+
+    @property
+    def triggered_policies(self) -> list[str]:
+        return [v.policy_name for v in self.violations if v.triggered]
+
+
+# ---------------------------------------------------------------------------
+# PolicyEvaluator
+# ---------------------------------------------------------------------------
+
+
+class PolicyEvaluator:
+    """Evaluates messages against DLP policies using Symantec 16.0 logic.
+
+    The evaluator takes a ParsedMessage, runs detection, and evaluates
+    all registered policies. Each policy is evaluated independently:
+
+    1. **Detection rules** (OR): Any rule matching triggers the policy.
+       Within a rule, all conditions use AND logic.
+    2. **Groups** (AND): If groups are defined, sender/recipient must
+       match at least one group.
+    3. **Exceptions**: Entire-message exceptions checked first. If any
+       applies, the policy is not violated. MCO exceptions then remove
+       specific matches.
+    4. **Severity**: Calculated from remaining match count against
+       severity level thresholds.
+
+    Example:
+        >>> evaluator = PolicyEvaluator(engine)
+        >>> evaluator.add_policy(pci_policy)
+        >>> result = evaluator.evaluate(message)
+        >>> if result.has_violations:
+        ...     print(result.highest_severity)
+    """
+
+    def __init__(self, engine: object | None = None) -> None:
+        """Initialize the evaluator.
+
+        Args:
+            engine: Optional DetectionEngine to run detection. If None,
+                detection results must be passed to evaluate_with_result().
+        """
+        self._engine = engine
+        self._policies: list[Policy] = []
+
+    @property
+    def policies(self) -> list[Policy]:
+        """Return registered policies (read-only copy)."""
+        return list(self._policies)
+
+    def add_policy(self, policy: Policy) -> None:
+        """Register a policy for evaluation.
+
+        Raises:
+            ValueError: If a policy with the same name already exists.
+        """
+        if any(p.name == policy.name for p in self._policies):
+            raise ValueError(
+                f"Policy with name {policy.name!r} already registered"
+            )
+        self._policies.append(policy)
+        logger.debug("Registered policy: %s", policy.name)
+
+    def remove_policy(self, name: str) -> None:
+        """Remove a policy by name.
+
+        Raises:
+            KeyError: If no policy with that name exists.
+        """
+        for i, p in enumerate(self._policies):
+            if p.name == name:
+                self._policies.pop(i)
+                logger.debug("Removed policy: %s", name)
+                return
+        raise KeyError(f"No policy registered with name {name!r}")
+
+    def evaluate(self, message: ParsedMessage) -> EvaluationResult:
+        """Run detection and evaluate all policies against a message.
+
+        Args:
+            message: The parsed message to evaluate.
+
+        Returns:
+            EvaluationResult with violations for each policy.
+
+        Raises:
+            RuntimeError: If no engine is configured.
+        """
+        if self._engine is None:
+            raise RuntimeError(
+                "No DetectionEngine configured. Use evaluate_with_result() "
+                "or pass an engine to the constructor."
+            )
+        detection = self._engine.detect(message)
+        return self.evaluate_with_result(message, detection)
+
+    def evaluate_with_result(
+        self,
+        message: ParsedMessage,
+        detection: DetectionResult,
+    ) -> EvaluationResult:
+        """Evaluate all policies given pre-computed detection results.
+
+        Args:
+            message: The parsed message.
+            detection: Pre-computed detection results.
+
+        Returns:
+            EvaluationResult with violations for each policy.
+        """
+        result = EvaluationResult(message_id=message.message_id)
+
+        for policy in self._policies:
+            if not policy.enabled:
+                continue
+
+            try:
+                violation = self._evaluate_policy(policy, message, detection)
+                result.violations.append(violation)
+            except Exception as exc:
+                logger.error(
+                    "Policy %r evaluation failed: %s",
+                    policy.name,
+                    exc,
+                    exc_info=True,
+                )
+                violation = PolicyViolation(
+                    policy_name=policy.name,
+                    errors=[f"Evaluation failed: {exc}"],
+                )
+                result.violations.append(violation)
+
+        return result
+
+    def _evaluate_policy(
+        self,
+        policy: Policy,
+        message: ParsedMessage,
+        detection: DetectionResult,
+    ) -> PolicyViolation:
+        """Evaluate a single policy against detection results."""
+        violation = PolicyViolation(policy_name=policy.name)
+
+        # Step 1: Detection rules (OR across rules)
+        matched_rules: list[str] = []
+        contributing_analyzers: set[str] = set()
+
+        for rule in policy.detection_rules:
+            if rule.evaluate(detection):
+                matched_rules.append(rule.name)
+                contributing_analyzers.update(
+                    rule.matched_analyzers(detection)
+                )
+
+        if not matched_rules:
+            # No detection rule matched — no violation
+            return violation
+
+        violation.matched_rules = matched_rules
+
+        # Step 2: Group constraints (AND with detection)
+        if policy.groups:
+            group_matched = any(
+                g.matches_message(message) for g in policy.groups
+            )
+            if not group_matched:
+                # Group constraint not satisfied — no violation
+                return violation
+
+        # Step 3: Collect matches from contributing analyzers
+        relevant_matches = [
+            m for m in detection.matches
+            if m.analyzer_name in contributing_analyzers
+        ]
+
+        # Step 4: Exception evaluation
+        # 4a: Entire-message exceptions first
+        for exc in policy.exceptions:
+            if exc.scope == ExceptionScope.ENTIRE_MESSAGE:
+                if exc.applies(message, detection):
+                    violation.exceptions_applied.append(exc.name)
+                    # Entire message exception — no violation
+                    return violation
+
+        # 4b: MCO (Matched Component Only) exceptions
+        for exc in policy.exceptions:
+            if exc.scope == ExceptionScope.COMPONENT:
+                if exc.applies(message, detection):
+                    before_count = len(relevant_matches)
+                    relevant_matches = exc.filter_matches(relevant_matches)
+                    if len(relevant_matches) < before_count:
+                        violation.exceptions_applied.append(exc.name)
+
+        # After exceptions, check if any matches remain
+        if not relevant_matches:
+            return violation
+
+        # Step 5: Policy is violated
+        violation.triggered = True
+        violation.matches = relevant_matches
+        violation.match_count = len(relevant_matches)
+
+        # Step 6: Severity calculation
+        violation.severity = self._calculate_severity(
+            policy, len(relevant_matches)
+        )
+
+        return violation
+
+    def _calculate_severity(
+        self, policy: Policy, match_count: int
+    ) -> Severity:
+        """Calculate severity based on match count and severity levels.
+
+        Severity levels are checked from highest min_matches to lowest.
+        The first level where match_count >= min_matches wins.
+        """
+        if not policy.severity_levels:
+            return policy.default_severity
+
+        # Sort by min_matches descending
+        sorted_levels = sorted(
+            policy.severity_levels, key=lambda s: s.min_matches, reverse=True
+        )
+
+        for level in sorted_levels:
+            if match_count >= level.min_matches:
+                return level.severity
+
+        return policy.default_severity

--- a/tests/detection/test_policy_evaluator.py
+++ b/tests/detection/test_policy_evaluator.py
@@ -1,0 +1,1846 @@
+"""Tests for PolicyEvaluator (P1-T8).
+
+Covers: compound rules (AND), multi-rule OR, detection+group AND,
+exception evaluation (entire message then MCO), severity calculation
+with match count thresholds, edge cases, and integration with
+DetectionEngine.
+"""
+
+import pytest
+
+from server.detection.engine import DetectionEngine
+from server.detection.analyzers.regex_analyzer import RegexAnalyzer, RegexPattern
+from server.detection.analyzers.keyword_analyzer import (
+    KeywordAnalyzer,
+    KeywordDictionaryConfig,
+)
+from server.detection.models import (
+    ComponentType,
+    DetectionResult,
+    Match,
+    MessageComponent,
+    ParsedMessage,
+)
+from server.detection.policy_evaluator import (
+    ConditionOperator,
+    DetectionRule,
+    EvaluationResult,
+    ExceptionScope,
+    GroupMatchMode,
+    Policy,
+    PolicyEvaluator,
+    PolicyException,
+    PolicyViolation,
+    RuleCondition,
+    SenderRecipientGroup,
+    Severity,
+    SeverityLevel,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_message(
+    body: str = "",
+    subject: str = "",
+    sender: str = "",
+    recipients: list[str] | None = None,
+    attachment_text: str = "",
+    attachment_meta: dict | None = None,
+) -> ParsedMessage:
+    """Create a test message with common fields."""
+    msg = ParsedMessage(
+        metadata={
+            "sender": sender,
+            "recipients": recipients or [],
+        }
+    )
+    if subject:
+        msg.add_component(ComponentType.SUBJECT, subject)
+    if body:
+        msg.add_component(ComponentType.BODY, body)
+    if attachment_text:
+        msg.add_component(
+            ComponentType.ATTACHMENT,
+            attachment_text,
+            metadata=attachment_meta or {"filename": "file.txt"},
+        )
+    return msg
+
+
+def _make_match(
+    analyzer_name: str = "test",
+    rule_name: str = "test_rule",
+    component_type: ComponentType = ComponentType.BODY,
+    matched_text: str = "test",
+) -> Match:
+    """Create a test match."""
+    comp = MessageComponent(component_type=component_type, content=matched_text)
+    return Match(
+        analyzer_name=analyzer_name,
+        rule_name=rule_name,
+        component=comp,
+        matched_text=matched_text,
+        start_offset=0,
+        end_offset=len(matched_text),
+    )
+
+
+def _make_detection(
+    matches: list[Match] | None = None,
+    message_id: str = "test-msg",
+) -> DetectionResult:
+    """Create a test detection result."""
+    return DetectionResult(
+        message_id=message_id,
+        matches=matches or [],
+    )
+
+
+def _ssn_engine() -> DetectionEngine:
+    """Engine with an SSN regex analyzer."""
+    engine = DetectionEngine()
+    engine.register(
+        RegexAnalyzer(
+            name="ssn_regex",
+            patterns=[
+                RegexPattern(name="US SSN", pattern=r"\b\d{3}-\d{2}-\d{4}\b")
+            ],
+        )
+    )
+    return engine
+
+
+def _cc_engine() -> DetectionEngine:
+    """Engine with a credit card regex analyzer."""
+    engine = DetectionEngine()
+    engine.register(
+        RegexAnalyzer(
+            name="cc_regex",
+            patterns=[
+                RegexPattern(
+                    name="Credit Card",
+                    pattern=r"\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b",
+                )
+            ],
+        )
+    )
+    return engine
+
+
+def _keyword_engine(keywords: list[str], name: str = "kw") -> DetectionEngine:
+    """Engine with a keyword analyzer."""
+    engine = DetectionEngine()
+    engine.register(
+        KeywordAnalyzer(
+            name=name,
+            dictionaries=[
+                KeywordDictionaryConfig(name="test_dict", keywords=keywords)
+            ],
+        )
+    )
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# RuleCondition tests
+# ---------------------------------------------------------------------------
+
+
+class TestRuleCondition:
+    """Test individual rule condition evaluation."""
+
+    def test_matches_operator_with_hits(self):
+        matches = [_make_match(analyzer_name="ssn")]
+        detection = _make_detection(matches)
+        cond = RuleCondition(analyzer_name="ssn")
+        assert cond.evaluate(detection) is True
+
+    def test_matches_operator_no_hits(self):
+        detection = _make_detection([])
+        cond = RuleCondition(analyzer_name="ssn")
+        assert cond.evaluate(detection) is False
+
+    def test_not_matches_operator(self):
+        detection = _make_detection([])
+        cond = RuleCondition(
+            analyzer_name="ssn", operator=ConditionOperator.NOT_MATCHES
+        )
+        assert cond.evaluate(detection) is True
+
+    def test_not_matches_with_hits(self):
+        matches = [_make_match(analyzer_name="ssn")]
+        detection = _make_detection(matches)
+        cond = RuleCondition(
+            analyzer_name="ssn", operator=ConditionOperator.NOT_MATCHES
+        )
+        assert cond.evaluate(detection) is False
+
+    def test_count_gte_operator(self):
+        matches = [_make_match(analyzer_name="ssn") for _ in range(5)]
+        detection = _make_detection(matches)
+
+        cond_3 = RuleCondition(
+            analyzer_name="ssn",
+            operator=ConditionOperator.COUNT_GTE,
+            threshold=3,
+        )
+        assert cond_3.evaluate(detection) is True
+
+        cond_10 = RuleCondition(
+            analyzer_name="ssn",
+            operator=ConditionOperator.COUNT_GTE,
+            threshold=10,
+        )
+        assert cond_10.evaluate(detection) is False
+
+    def test_count_lte_operator(self):
+        matches = [_make_match(analyzer_name="ssn") for _ in range(3)]
+        detection = _make_detection(matches)
+
+        cond = RuleCondition(
+            analyzer_name="ssn",
+            operator=ConditionOperator.COUNT_LTE,
+            threshold=5,
+        )
+        assert cond.evaluate(detection) is True
+
+    def test_component_type_filter(self):
+        """Condition filtered to body components only."""
+        body_match = _make_match(
+            analyzer_name="ssn", component_type=ComponentType.BODY
+        )
+        attach_match = _make_match(
+            analyzer_name="ssn", component_type=ComponentType.ATTACHMENT
+        )
+        detection = _make_detection([body_match, attach_match])
+
+        cond = RuleCondition(
+            analyzer_name="ssn",
+            operator=ConditionOperator.COUNT_GTE,
+            threshold=2,
+            component_types=[ComponentType.BODY],
+        )
+        # Only 1 body match, threshold is 2
+        assert cond.evaluate(detection) is False
+
+        cond_1 = RuleCondition(
+            analyzer_name="ssn",
+            operator=ConditionOperator.COUNT_GTE,
+            threshold=1,
+            component_types=[ComponentType.BODY],
+        )
+        assert cond_1.evaluate(detection) is True
+
+
+# ---------------------------------------------------------------------------
+# DetectionRule tests (AND logic within a rule)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectionRule:
+    """Test compound rules with AND logic."""
+
+    def test_single_condition_matches(self):
+        matches = [_make_match(analyzer_name="ssn")]
+        detection = _make_detection(matches)
+
+        rule = DetectionRule(
+            name="ssn_rule",
+            conditions=[RuleCondition(analyzer_name="ssn")],
+        )
+        assert rule.evaluate(detection) is True
+
+    def test_single_condition_no_match(self):
+        detection = _make_detection([])
+        rule = DetectionRule(
+            name="ssn_rule",
+            conditions=[RuleCondition(analyzer_name="ssn")],
+        )
+        assert rule.evaluate(detection) is False
+
+    def test_compound_rule_and_both_match(self):
+        """Acceptance: compound rule (keyword AND file type) both match."""
+        matches = [
+            _make_match(analyzer_name="kw"),
+            _make_match(analyzer_name="ft"),
+        ]
+        detection = _make_detection(matches)
+
+        rule = DetectionRule(
+            name="compound",
+            conditions=[
+                RuleCondition(analyzer_name="kw"),
+                RuleCondition(analyzer_name="ft"),
+            ],
+        )
+        assert rule.evaluate(detection) is True
+
+    def test_compound_rule_and_one_misses(self):
+        """Acceptance: compound rule — one condition misses → no match."""
+        matches = [_make_match(analyzer_name="kw")]
+        detection = _make_detection(matches)
+
+        rule = DetectionRule(
+            name="compound",
+            conditions=[
+                RuleCondition(analyzer_name="kw"),
+                RuleCondition(analyzer_name="ft"),
+            ],
+        )
+        assert rule.evaluate(detection) is False
+
+    def test_empty_conditions_no_match(self):
+        detection = _make_detection([_make_match()])
+        rule = DetectionRule(name="empty", conditions=[])
+        assert rule.evaluate(detection) is False
+
+    def test_matched_analyzers(self):
+        matches = [
+            _make_match(analyzer_name="kw"),
+            _make_match(analyzer_name="ft"),
+        ]
+        detection = _make_detection(matches)
+
+        rule = DetectionRule(
+            name="compound",
+            conditions=[
+                RuleCondition(analyzer_name="kw"),
+                RuleCondition(analyzer_name="ft"),
+            ],
+        )
+        assert rule.matched_analyzers(detection) == {"kw", "ft"}
+
+    def test_three_condition_and(self):
+        """Three conditions, all must match."""
+        matches = [
+            _make_match(analyzer_name="a"),
+            _make_match(analyzer_name="b"),
+            _make_match(analyzer_name="c"),
+        ]
+        detection = _make_detection(matches)
+
+        rule = DetectionRule(
+            name="triple",
+            conditions=[
+                RuleCondition(analyzer_name="a"),
+                RuleCondition(analyzer_name="b"),
+                RuleCondition(analyzer_name="c"),
+            ],
+        )
+        assert rule.evaluate(detection) is True
+
+        # Remove one → fails
+        detection2 = _make_detection(matches[:2])
+        assert rule.evaluate(detection2) is False
+
+
+# ---------------------------------------------------------------------------
+# Multi-rule OR logic
+# ---------------------------------------------------------------------------
+
+
+class TestMultiRuleOR:
+    """Test OR logic across multiple detection rules."""
+
+    def test_first_rule_matches(self):
+        matches = [_make_match(analyzer_name="ssn")]
+        detection = _make_detection(matches)
+
+        policy = Policy(
+            name="test",
+            detection_rules=[
+                DetectionRule(
+                    name="ssn_rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                ),
+                DetectionRule(
+                    name="cc_rule",
+                    conditions=[RuleCondition(analyzer_name="cc")],
+                ),
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+        result = evaluator.evaluate_with_result(
+            _make_message(), detection
+        )
+
+        assert result.has_violations
+        v = result.violations[0]
+        assert "ssn_rule" in v.matched_rules
+
+    def test_second_rule_matches(self):
+        matches = [_make_match(analyzer_name="cc")]
+        detection = _make_detection(matches)
+
+        policy = Policy(
+            name="test",
+            detection_rules=[
+                DetectionRule(
+                    name="ssn_rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                ),
+                DetectionRule(
+                    name="cc_rule",
+                    conditions=[RuleCondition(analyzer_name="cc")],
+                ),
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+        result = evaluator.evaluate_with_result(
+            _make_message(), detection
+        )
+
+        assert result.has_violations
+        v = result.violations[0]
+        assert "cc_rule" in v.matched_rules
+
+    def test_both_rules_match(self):
+        matches = [
+            _make_match(analyzer_name="ssn"),
+            _make_match(analyzer_name="cc"),
+        ]
+        detection = _make_detection(matches)
+
+        policy = Policy(
+            name="test",
+            detection_rules=[
+                DetectionRule(
+                    name="ssn_rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                ),
+                DetectionRule(
+                    name="cc_rule",
+                    conditions=[RuleCondition(analyzer_name="cc")],
+                ),
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+        result = evaluator.evaluate_with_result(
+            _make_message(), detection
+        )
+
+        assert result.has_violations
+        v = result.violations[0]
+        assert "ssn_rule" in v.matched_rules
+        assert "cc_rule" in v.matched_rules
+
+    def test_no_rules_match(self):
+        detection = _make_detection([])
+
+        policy = Policy(
+            name="test",
+            detection_rules=[
+                DetectionRule(
+                    name="ssn_rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                ),
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+        result = evaluator.evaluate_with_result(
+            _make_message(), detection
+        )
+
+        assert not result.has_violations
+
+
+# ---------------------------------------------------------------------------
+# Group AND logic
+# ---------------------------------------------------------------------------
+
+
+class TestGroupConstraints:
+    """Test sender/recipient group AND logic."""
+
+    def test_sender_exact_match(self):
+        group = SenderRecipientGroup(
+            name="Executives",
+            members=["ceo@company.com", "cto@company.com"],
+            match_mode=GroupMatchMode.EXACT,
+            field="sender",
+        )
+        msg = _make_message(sender="ceo@company.com")
+        assert group.matches_message(msg) is True
+
+    def test_sender_no_match(self):
+        group = SenderRecipientGroup(
+            name="Executives",
+            members=["ceo@company.com"],
+            field="sender",
+        )
+        msg = _make_message(sender="intern@company.com")
+        assert group.matches_message(msg) is False
+
+    def test_domain_match(self):
+        group = SenderRecipientGroup(
+            name="External",
+            members=["external.com"],
+            match_mode=GroupMatchMode.DOMAIN,
+            field="sender",
+        )
+        msg = _make_message(sender="anyone@external.com")
+        assert group.matches_message(msg) is True
+
+    def test_domain_subdomain_match(self):
+        group = SenderRecipientGroup(
+            name="External",
+            members=["external.com"],
+            match_mode=GroupMatchMode.DOMAIN,
+            field="sender",
+        )
+        msg = _make_message(sender="user@sub.external.com")
+        assert group.matches_message(msg) is True
+
+    def test_domain_no_match(self):
+        group = SenderRecipientGroup(
+            name="External",
+            members=["external.com"],
+            match_mode=GroupMatchMode.DOMAIN,
+            field="sender",
+        )
+        msg = _make_message(sender="user@internal.com")
+        assert group.matches_message(msg) is False
+
+    def test_regex_match(self):
+        group = SenderRecipientGroup(
+            name="VIPs",
+            members=[r"^(ceo|cto|cfo)@"],
+            match_mode=GroupMatchMode.REGEX,
+            field="sender",
+        )
+        msg = _make_message(sender="ceo@company.com")
+        assert group.matches_message(msg) is True
+
+    def test_recipients_any_match(self):
+        group = SenderRecipientGroup(
+            name="Confidential Recipients",
+            members=["external@partner.com"],
+            field="recipients",
+        )
+        msg = _make_message(
+            recipients=["internal@company.com", "external@partner.com"]
+        )
+        assert group.matches_message(msg) is True
+
+    def test_case_insensitive(self):
+        group = SenderRecipientGroup(
+            name="Test",
+            members=["CEO@Company.COM"],
+            field="sender",
+        )
+        msg = _make_message(sender="ceo@company.com")
+        assert group.matches_message(msg) is True
+
+    def test_group_and_detection_both_required(self):
+        """Detection matches + group matches → violation."""
+        matches = [_make_match(analyzer_name="ssn")]
+        detection = _make_detection(matches)
+
+        policy = Policy(
+            name="sensitive_for_externals",
+            detection_rules=[
+                DetectionRule(
+                    name="ssn_rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            groups=[
+                SenderRecipientGroup(
+                    name="External Recipients",
+                    members=["external.com"],
+                    match_mode=GroupMatchMode.DOMAIN,
+                    field="recipients",
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        # External recipient → violation
+        msg = _make_message(recipients=["user@external.com"])
+        result = evaluator.evaluate_with_result(msg, detection)
+        assert result.has_violations
+
+    def test_group_not_matched_no_violation(self):
+        """Detection matches but group doesn't → no violation."""
+        matches = [_make_match(analyzer_name="ssn")]
+        detection = _make_detection(matches)
+
+        policy = Policy(
+            name="sensitive_for_externals",
+            detection_rules=[
+                DetectionRule(
+                    name="ssn_rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            groups=[
+                SenderRecipientGroup(
+                    name="External",
+                    members=["external.com"],
+                    match_mode=GroupMatchMode.DOMAIN,
+                    field="recipients",
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        # Internal recipient → no violation
+        msg = _make_message(recipients=["user@internal.com"])
+        result = evaluator.evaluate_with_result(msg, detection)
+        assert not result.has_violations
+
+
+# ---------------------------------------------------------------------------
+# Exceptions: entire message
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionEntireMessage:
+    """Test entire-message exception evaluation."""
+
+    def test_sender_exception_blocks_incident(self):
+        """Acceptance: exception for sender → no incident."""
+        matches = [_make_match(analyzer_name="ssn")]
+        detection = _make_detection(matches)
+
+        policy = Policy(
+            name="ssn_policy",
+            detection_rules=[
+                DetectionRule(
+                    name="ssn_rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            exceptions=[
+                PolicyException(
+                    name="ceo_exception",
+                    scope=ExceptionScope.ENTIRE_MESSAGE,
+                    groups=[
+                        SenderRecipientGroup(
+                            name="CEO",
+                            members=["ceo@company.com"],
+                            field="sender",
+                        )
+                    ],
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        msg = _make_message(sender="ceo@company.com", body="SSN: 123-45-6789")
+        result = evaluator.evaluate_with_result(msg, detection)
+
+        assert not result.has_violations
+        v = result.violations[0]
+        assert "ceo_exception" in v.exceptions_applied
+
+    def test_non_matching_sender_not_excepted(self):
+        matches = [_make_match(analyzer_name="ssn")]
+        detection = _make_detection(matches)
+
+        policy = Policy(
+            name="ssn_policy",
+            detection_rules=[
+                DetectionRule(
+                    name="ssn_rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            exceptions=[
+                PolicyException(
+                    name="ceo_exception",
+                    scope=ExceptionScope.ENTIRE_MESSAGE,
+                    groups=[
+                        SenderRecipientGroup(
+                            name="CEO",
+                            members=["ceo@company.com"],
+                            field="sender",
+                        )
+                    ],
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        msg = _make_message(sender="intern@company.com", body="SSN: 123-45-6789")
+        result = evaluator.evaluate_with_result(msg, detection)
+        assert result.has_violations
+
+    def test_custom_condition_exception(self):
+        """Exception with custom condition function."""
+        matches = [_make_match(analyzer_name="ssn")]
+        detection = _make_detection(matches)
+
+        policy = Policy(
+            name="test",
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            exceptions=[
+                PolicyException(
+                    name="internal_only",
+                    scope=ExceptionScope.ENTIRE_MESSAGE,
+                    condition=lambda msg, det: msg.metadata.get("channel") == "internal",
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        # Internal channel → excepted
+        msg = _make_message()
+        msg.metadata["channel"] = "internal"
+        result = evaluator.evaluate_with_result(msg, detection)
+        assert not result.has_violations
+
+        # External channel → not excepted
+        msg2 = _make_message()
+        msg2.metadata["channel"] = "external"
+        result2 = evaluator.evaluate_with_result(msg2, detection)
+        assert result2.has_violations
+
+
+# ---------------------------------------------------------------------------
+# Exceptions: MCO (Matched Component Only)
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionMCO:
+    """Test MCO exception evaluation."""
+
+    def test_mco_removes_only_matched_component(self):
+        """Acceptance: MCO exception removes only matched component, not entire message."""
+        body_match = _make_match(
+            analyzer_name="ssn",
+            component_type=ComponentType.BODY,
+            matched_text="123-45-6789",
+        )
+        attach_match = _make_match(
+            analyzer_name="ssn",
+            component_type=ComponentType.ATTACHMENT,
+            matched_text="987-65-4321",
+        )
+        detection = _make_detection([body_match, attach_match])
+
+        policy = Policy(
+            name="ssn_policy",
+            detection_rules=[
+                DetectionRule(
+                    name="ssn_rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            exceptions=[
+                PolicyException(
+                    name="body_exception",
+                    scope=ExceptionScope.COMPONENT,
+                    component_types=[ComponentType.BODY],
+                    analyzer_names=["ssn"],
+                    # Always applies for this test
+                    condition=lambda msg, det: True,
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        result = evaluator.evaluate_with_result(_make_message(), detection)
+
+        assert result.has_violations
+        v = result.violations[0]
+        # Body match removed, attachment match remains
+        assert v.match_count == 1
+        assert v.matches[0].component.component_type == ComponentType.ATTACHMENT
+        assert "body_exception" in v.exceptions_applied
+
+    def test_mco_by_analyzer_name(self):
+        """MCO exception filtering by analyzer name only."""
+        ssn_match = _make_match(analyzer_name="ssn")
+        cc_match = _make_match(analyzer_name="cc")
+        detection = _make_detection([ssn_match, cc_match])
+
+        policy = Policy(
+            name="test",
+            detection_rules=[
+                DetectionRule(
+                    name="r1",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                ),
+                DetectionRule(
+                    name="r2",
+                    conditions=[RuleCondition(analyzer_name="cc")],
+                ),
+            ],
+            exceptions=[
+                PolicyException(
+                    name="exclude_ssn",
+                    scope=ExceptionScope.COMPONENT,
+                    analyzer_names=["ssn"],
+                    condition=lambda msg, det: True,
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        result = evaluator.evaluate_with_result(_make_message(), detection)
+        v = result.violations[0]
+        assert v.triggered
+        assert v.match_count == 1
+        assert v.matches[0].analyzer_name == "cc"
+
+    def test_mco_removes_all_no_violation(self):
+        """MCO removes all matches → no violation."""
+        match = _make_match(analyzer_name="ssn", component_type=ComponentType.BODY)
+        detection = _make_detection([match])
+
+        policy = Policy(
+            name="test",
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            exceptions=[
+                PolicyException(
+                    name="exclude_body",
+                    scope=ExceptionScope.COMPONENT,
+                    component_types=[ComponentType.BODY],
+                    analyzer_names=["ssn"],
+                    condition=lambda msg, det: True,
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        result = evaluator.evaluate_with_result(_make_message(), detection)
+        assert not result.has_violations
+
+    def test_entire_message_checked_before_mco(self):
+        """Entire-message exceptions are evaluated before MCO."""
+        match = _make_match(analyzer_name="ssn")
+        detection = _make_detection([match])
+
+        mco_called = {"value": False}
+
+        def mco_condition(msg, det):
+            mco_called["value"] = True
+            return True
+
+        policy = Policy(
+            name="test",
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            exceptions=[
+                PolicyException(
+                    name="entire_exc",
+                    scope=ExceptionScope.ENTIRE_MESSAGE,
+                    condition=lambda msg, det: True,
+                ),
+                PolicyException(
+                    name="mco_exc",
+                    scope=ExceptionScope.COMPONENT,
+                    condition=mco_condition,
+                ),
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        result = evaluator.evaluate_with_result(_make_message(), detection)
+        assert not result.has_violations
+        # MCO should NOT be called because entire-message exception fired first
+        assert mco_called["value"] is False
+
+
+# ---------------------------------------------------------------------------
+# Severity calculation
+# ---------------------------------------------------------------------------
+
+
+class TestSeverityCalculation:
+    """Test severity tier calculation from match counts."""
+
+    def test_severity_tiers(self):
+        """Acceptance: 3 matches → Medium, 10 → High."""
+        policy = Policy(
+            name="tiered",
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            severity_levels=[
+                SeverityLevel(severity=Severity.LOW, min_matches=1),
+                SeverityLevel(severity=Severity.MEDIUM, min_matches=3),
+                SeverityLevel(severity=Severity.HIGH, min_matches=10),
+                SeverityLevel(severity=Severity.CRITICAL, min_matches=50),
+            ],
+            default_severity=Severity.INFO,
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        # 1 match → Low
+        detection_1 = _make_detection(
+            [_make_match(analyzer_name="ssn") for _ in range(1)]
+        )
+        r = evaluator.evaluate_with_result(_make_message(), detection_1)
+        assert r.violations[0].severity == Severity.LOW
+
+        # 3 matches → Medium
+        detection_3 = _make_detection(
+            [_make_match(analyzer_name="ssn") for _ in range(3)]
+        )
+        r = evaluator.evaluate_with_result(_make_message(), detection_3)
+        assert r.violations[0].severity == Severity.MEDIUM
+
+        # 10 matches → High
+        detection_10 = _make_detection(
+            [_make_match(analyzer_name="ssn") for _ in range(10)]
+        )
+        r = evaluator.evaluate_with_result(_make_message(), detection_10)
+        assert r.violations[0].severity == Severity.HIGH
+
+        # 50 matches → Critical
+        detection_50 = _make_detection(
+            [_make_match(analyzer_name="ssn") for _ in range(50)]
+        )
+        r = evaluator.evaluate_with_result(_make_message(), detection_50)
+        assert r.violations[0].severity == Severity.CRITICAL
+
+    def test_default_severity_when_no_tiers(self):
+        policy = Policy(
+            name="simple",
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            default_severity=Severity.MEDIUM,
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        detection = _make_detection([_make_match(analyzer_name="ssn")])
+        r = evaluator.evaluate_with_result(_make_message(), detection)
+        assert r.violations[0].severity == Severity.MEDIUM
+
+    def test_default_severity_below_all_tiers(self):
+        """Match count below all tier thresholds → default severity."""
+        policy = Policy(
+            name="high_threshold",
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            severity_levels=[
+                SeverityLevel(severity=Severity.HIGH, min_matches=100),
+            ],
+            default_severity=Severity.INFO,
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        detection = _make_detection([_make_match(analyzer_name="ssn")])
+        r = evaluator.evaluate_with_result(_make_message(), detection)
+        assert r.violations[0].severity == Severity.INFO
+
+    def test_severity_after_mco_reduction(self):
+        """Severity calculated after MCO removes matches."""
+        matches = [_make_match(analyzer_name="ssn") for _ in range(10)]
+        # Make 7 of them body matches, 3 attachment
+        for i, m in enumerate(matches):
+            if i < 7:
+                m.component = MessageComponent(
+                    component_type=ComponentType.BODY, content="test"
+                )
+            else:
+                m.component = MessageComponent(
+                    component_type=ComponentType.ATTACHMENT, content="test"
+                )
+
+        detection = _make_detection(matches)
+
+        policy = Policy(
+            name="test",
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            exceptions=[
+                PolicyException(
+                    name="exclude_body",
+                    scope=ExceptionScope.COMPONENT,
+                    component_types=[ComponentType.BODY],
+                    analyzer_names=["ssn"],
+                    condition=lambda msg, det: True,
+                )
+            ],
+            severity_levels=[
+                SeverityLevel(severity=Severity.LOW, min_matches=1),
+                SeverityLevel(severity=Severity.MEDIUM, min_matches=5),
+                SeverityLevel(severity=Severity.HIGH, min_matches=10),
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        result = evaluator.evaluate_with_result(_make_message(), detection)
+        v = result.violations[0]
+        # 7 body removed, 3 attachment remain → Low (not Medium or High)
+        assert v.match_count == 3
+        assert v.severity == Severity.LOW
+
+
+# ---------------------------------------------------------------------------
+# PolicyEvaluator — management and multi-policy
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyEvaluatorManagement:
+    """Test policy management operations."""
+
+    def test_add_duplicate_policy_raises(self):
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(Policy(name="test"))
+        with pytest.raises(ValueError, match="already registered"):
+            evaluator.add_policy(Policy(name="test"))
+
+    def test_remove_policy(self):
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(Policy(name="test"))
+        evaluator.remove_policy("test")
+        assert len(evaluator.policies) == 0
+
+    def test_remove_nonexistent_raises(self):
+        evaluator = PolicyEvaluator()
+        with pytest.raises(KeyError):
+            evaluator.remove_policy("nonexistent")
+
+    def test_policies_read_only(self):
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(Policy(name="test"))
+        policies = evaluator.policies
+        policies.clear()
+        assert len(evaluator.policies) == 1
+
+    def test_disabled_policy_skipped(self):
+        matches = [_make_match(analyzer_name="ssn")]
+        detection = _make_detection(matches)
+
+        policy = Policy(
+            name="disabled",
+            enabled=False,
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        result = evaluator.evaluate_with_result(_make_message(), detection)
+        assert len(result.violations) == 0
+
+    def test_multiple_policies_independent(self):
+        """Each policy evaluated independently."""
+        ssn_match = _make_match(analyzer_name="ssn")
+        cc_match = _make_match(analyzer_name="cc")
+        detection = _make_detection([ssn_match, cc_match])
+
+        ssn_policy = Policy(
+            name="SSN Policy",
+            detection_rules=[
+                DetectionRule(
+                    name="ssn_rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+        )
+        cc_policy = Policy(
+            name="CC Policy",
+            detection_rules=[
+                DetectionRule(
+                    name="cc_rule",
+                    conditions=[RuleCondition(analyzer_name="cc")],
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(ssn_policy)
+        evaluator.add_policy(cc_policy)
+
+        result = evaluator.evaluate_with_result(_make_message(), detection)
+        assert len(result.violations) == 2
+        assert all(v.triggered for v in result.violations)
+
+    def test_evaluate_without_engine_raises(self):
+        evaluator = PolicyEvaluator()
+        with pytest.raises(RuntimeError, match="No DetectionEngine"):
+            evaluator.evaluate(_make_message())
+
+
+# ---------------------------------------------------------------------------
+# EvaluationResult properties
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluationResult:
+
+    def test_has_violations_false(self):
+        result = EvaluationResult(message_id="test")
+        assert result.has_violations is False
+        assert result.highest_severity is None
+        assert result.triggered_policies == []
+
+    def test_highest_severity(self):
+        result = EvaluationResult(
+            message_id="test",
+            violations=[
+                PolicyViolation(
+                    policy_name="p1", triggered=True, severity=Severity.LOW
+                ),
+                PolicyViolation(
+                    policy_name="p2", triggered=True, severity=Severity.HIGH
+                ),
+                PolicyViolation(
+                    policy_name="p3", triggered=False, severity=Severity.CRITICAL
+                ),
+            ],
+        )
+        # p3 is not triggered, so HIGH is the highest
+        assert result.highest_severity == Severity.HIGH
+        assert result.triggered_policies == ["p1", "p2"]
+
+
+# ---------------------------------------------------------------------------
+# Integration with DetectionEngine
+# ---------------------------------------------------------------------------
+
+
+class TestEngineIntegration:
+    """Test PolicyEvaluator with real DetectionEngine."""
+
+    def test_ssn_detection_triggers_policy(self):
+        engine = _ssn_engine()
+
+        policy = Policy(
+            name="PII Policy",
+            detection_rules=[
+                DetectionRule(
+                    name="ssn_rule",
+                    conditions=[
+                        RuleCondition(analyzer_name="ssn_regex")
+                    ],
+                )
+            ],
+            severity_levels=[
+                SeverityLevel(severity=Severity.LOW, min_matches=1),
+                SeverityLevel(severity=Severity.MEDIUM, min_matches=3),
+                SeverityLevel(severity=Severity.HIGH, min_matches=10),
+            ],
+        )
+
+        evaluator = PolicyEvaluator(engine)
+        evaluator.add_policy(policy)
+
+        msg = _make_message(body="SSN: 123-45-6789")
+        result = evaluator.evaluate(msg)
+
+        assert result.has_violations
+        v = result.violations[0]
+        assert v.triggered
+        assert v.severity == Severity.LOW
+        assert v.match_count == 1
+
+    def test_multiple_ssns_severity_escalation(self):
+        engine = _ssn_engine()
+
+        policy = Policy(
+            name="PII Policy",
+            detection_rules=[
+                DetectionRule(
+                    name="ssn_rule",
+                    conditions=[
+                        RuleCondition(analyzer_name="ssn_regex")
+                    ],
+                )
+            ],
+            severity_levels=[
+                SeverityLevel(severity=Severity.LOW, min_matches=1),
+                SeverityLevel(severity=Severity.MEDIUM, min_matches=3),
+                SeverityLevel(severity=Severity.HIGH, min_matches=5),
+            ],
+        )
+
+        evaluator = PolicyEvaluator(engine)
+        evaluator.add_policy(policy)
+
+        ssns = " ".join(
+            f"{100+i}-{10+i}-{1000+i}" for i in range(5)
+        )
+        msg = _make_message(body=f"SSNs: {ssns}")
+        result = evaluator.evaluate(msg)
+
+        v = result.violations[0]
+        assert v.triggered
+        assert v.match_count == 5
+        assert v.severity == Severity.HIGH
+
+    def test_compound_keyword_and_regex(self):
+        """Compound: keyword AND regex both must match."""
+        engine = DetectionEngine()
+        engine.register(
+            KeywordAnalyzer(
+                name="kw",
+                dictionaries=[
+                    KeywordDictionaryConfig(
+                        name="pii_kw", keywords=["confidential", "secret"]
+                    )
+                ],
+            )
+        )
+        engine.register(
+            RegexAnalyzer(
+                name="ssn_regex",
+                patterns=[
+                    RegexPattern(
+                        name="US SSN", pattern=r"\b\d{3}-\d{2}-\d{4}\b"
+                    )
+                ],
+            )
+        )
+
+        policy = Policy(
+            name="Compound PII",
+            detection_rules=[
+                DetectionRule(
+                    name="kw_and_ssn",
+                    conditions=[
+                        RuleCondition(analyzer_name="kw"),
+                        RuleCondition(analyzer_name="ssn_regex"),
+                    ],
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator(engine)
+        evaluator.add_policy(policy)
+
+        # Both present → violation
+        msg1 = _make_message(body="CONFIDENTIAL: SSN 123-45-6789")
+        r1 = evaluator.evaluate(msg1)
+        assert r1.has_violations
+
+        # Only keyword → no violation
+        msg2 = _make_message(body="This is CONFIDENTIAL information")
+        r2 = evaluator.evaluate(msg2)
+        assert not r2.has_violations
+
+        # Only SSN → no violation
+        msg3 = _make_message(body="Number: 123-45-6789")
+        r3 = evaluator.evaluate(msg3)
+        assert not r3.has_violations
+
+    def test_exception_for_sender_with_engine(self):
+        """Full integration: detection + policy + sender exception."""
+        engine = _ssn_engine()
+
+        policy = Policy(
+            name="PII Policy",
+            detection_rules=[
+                DetectionRule(
+                    name="ssn_rule",
+                    conditions=[
+                        RuleCondition(analyzer_name="ssn_regex")
+                    ],
+                )
+            ],
+            exceptions=[
+                PolicyException(
+                    name="CEO Exception",
+                    scope=ExceptionScope.ENTIRE_MESSAGE,
+                    groups=[
+                        SenderRecipientGroup(
+                            name="CEO",
+                            members=["ceo@company.com"],
+                            field="sender",
+                        )
+                    ],
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator(engine)
+        evaluator.add_policy(policy)
+
+        # CEO sends SSN → no incident
+        msg = _make_message(
+            sender="ceo@company.com", body="SSN: 123-45-6789"
+        )
+        result = evaluator.evaluate(msg)
+        assert not result.has_violations
+
+        # Regular employee → incident
+        msg2 = _make_message(
+            sender="employee@company.com", body="SSN: 123-45-6789"
+        )
+        result2 = evaluator.evaluate(msg2)
+        assert result2.has_violations
+
+    def test_count_threshold_condition(self):
+        """Rule with COUNT_GTE: only trigger if 3+ matches."""
+        engine = _ssn_engine()
+
+        policy = Policy(
+            name="Bulk SSN",
+            detection_rules=[
+                DetectionRule(
+                    name="bulk_ssn",
+                    conditions=[
+                        RuleCondition(
+                            analyzer_name="ssn_regex",
+                            operator=ConditionOperator.COUNT_GTE,
+                            threshold=3,
+                        )
+                    ],
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator(engine)
+        evaluator.add_policy(policy)
+
+        # 2 SSNs → no violation
+        msg1 = _make_message(body="100-20-3000 200-30-4000")
+        r1 = evaluator.evaluate(msg1)
+        assert not r1.has_violations
+
+        # 3 SSNs → violation
+        msg2 = _make_message(body="100-20-3000 200-30-4000 300-40-5000")
+        r2 = evaluator.evaluate(msg2)
+        assert r2.has_violations
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+
+    def test_no_policies_no_violations(self):
+        evaluator = PolicyEvaluator()
+        result = evaluator.evaluate_with_result(
+            _make_message(), _make_detection([])
+        )
+        assert not result.has_violations
+        assert len(result.violations) == 0
+
+    def test_no_detection_rules_no_violation(self):
+        policy = Policy(name="empty")
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        detection = _make_detection([_make_match()])
+        result = evaluator.evaluate_with_result(_make_message(), detection)
+        assert not result.has_violations
+
+    def test_policy_evaluation_error_captured(self):
+        """Analyzer error during evaluation → captured, not raised."""
+        detection = _make_detection([_make_match(analyzer_name="ssn")])
+
+        def bad_condition(msg, det):
+            raise RuntimeError("boom")
+
+        policy = Policy(
+            name="buggy",
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            exceptions=[
+                PolicyException(
+                    name="bad_exc",
+                    scope=ExceptionScope.ENTIRE_MESSAGE,
+                    condition=bad_condition,
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        # The exception in the condition should be caught at the policy level
+        result = evaluator.evaluate_with_result(_make_message(), detection)
+        v = result.violations[0]
+        assert len(v.errors) >= 1
+
+    def test_multiple_exceptions_first_entire_wins(self):
+        """Multiple entire-message exceptions: first match wins."""
+        match = _make_match(analyzer_name="ssn")
+        detection = _make_detection([match])
+
+        policy = Policy(
+            name="test",
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            exceptions=[
+                PolicyException(
+                    name="exc1",
+                    scope=ExceptionScope.ENTIRE_MESSAGE,
+                    condition=lambda msg, det: True,
+                ),
+                PolicyException(
+                    name="exc2",
+                    scope=ExceptionScope.ENTIRE_MESSAGE,
+                    condition=lambda msg, det: True,
+                ),
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        result = evaluator.evaluate_with_result(_make_message(), detection)
+        v = result.violations[0]
+        assert not v.triggered
+        # Only first exception name recorded
+        assert "exc1" in v.exceptions_applied
+
+    def test_empty_message_metadata(self):
+        """Message with no sender/recipients metadata."""
+        match = _make_match(analyzer_name="ssn")
+        detection = _make_detection([match])
+
+        policy = Policy(
+            name="test",
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            groups=[
+                SenderRecipientGroup(
+                    name="External",
+                    members=["external.com"],
+                    match_mode=GroupMatchMode.DOMAIN,
+                    field="sender",
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        msg = ParsedMessage()  # No metadata
+        result = evaluator.evaluate_with_result(msg, detection)
+        assert not result.has_violations
+
+
+# ---------------------------------------------------------------------------
+# Adversarial / robustness tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialAndRobustness:
+    """Additional robustness tests for the XL-complexity PolicyEvaluator."""
+
+    def test_multiple_mco_exceptions_stacking(self):
+        """Two MCO exceptions remove different component types independently."""
+        body_match = _make_match(
+            analyzer_name="ssn", component_type=ComponentType.BODY
+        )
+        attach_match = _make_match(
+            analyzer_name="ssn", component_type=ComponentType.ATTACHMENT
+        )
+        subject_match = _make_match(
+            analyzer_name="ssn", component_type=ComponentType.SUBJECT
+        )
+        detection = _make_detection([body_match, attach_match, subject_match])
+
+        policy = Policy(
+            name="test",
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            exceptions=[
+                PolicyException(
+                    name="exclude_body",
+                    scope=ExceptionScope.COMPONENT,
+                    component_types=[ComponentType.BODY],
+                    analyzer_names=["ssn"],
+                    condition=lambda msg, det: True,
+                ),
+                PolicyException(
+                    name="exclude_attachment",
+                    scope=ExceptionScope.COMPONENT,
+                    component_types=[ComponentType.ATTACHMENT],
+                    analyzer_names=["ssn"],
+                    condition=lambda msg, det: True,
+                ),
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        result = evaluator.evaluate_with_result(_make_message(), detection)
+        v = result.violations[0]
+        assert v.triggered
+        assert v.match_count == 1
+        assert v.matches[0].component.component_type == ComponentType.SUBJECT
+        assert "exclude_body" in v.exceptions_applied
+        assert "exclude_attachment" in v.exceptions_applied
+
+    def test_severity_boundary_exactly_at_threshold(self):
+        """Exactly at tier boundary: 3 matches = Medium, 2 = Low."""
+        policy = Policy(
+            name="boundary",
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            severity_levels=[
+                SeverityLevel(severity=Severity.LOW, min_matches=1),
+                SeverityLevel(severity=Severity.MEDIUM, min_matches=3),
+                SeverityLevel(severity=Severity.HIGH, min_matches=10),
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        # Exactly 2 → Low (below Medium threshold)
+        det_2 = _make_detection(
+            [_make_match(analyzer_name="ssn") for _ in range(2)]
+        )
+        r2 = evaluator.evaluate_with_result(_make_message(), det_2)
+        assert r2.violations[0].severity == Severity.LOW
+
+        # Exactly 3 → Medium (at boundary)
+        det_3 = _make_detection(
+            [_make_match(analyzer_name="ssn") for _ in range(3)]
+        )
+        r3 = evaluator.evaluate_with_result(_make_message(), det_3)
+        assert r3.violations[0].severity == Severity.MEDIUM
+
+        # Exactly 9 → Medium (below High)
+        det_9 = _make_detection(
+            [_make_match(analyzer_name="ssn") for _ in range(9)]
+        )
+        r9 = evaluator.evaluate_with_result(_make_message(), det_9)
+        assert r9.violations[0].severity == Severity.MEDIUM
+
+        # Exactly 10 → High (at boundary)
+        det_10 = _make_detection(
+            [_make_match(analyzer_name="ssn") for _ in range(10)]
+        )
+        r10 = evaluator.evaluate_with_result(_make_message(), det_10)
+        assert r10.violations[0].severity == Severity.HIGH
+
+    def test_multi_policy_different_outcomes(self):
+        """Two policies: one triggers, one doesn't."""
+        ssn_match = _make_match(analyzer_name="ssn")
+        detection = _make_detection([ssn_match])
+
+        ssn_policy = Policy(
+            name="SSN Policy",
+            detection_rules=[
+                DetectionRule(
+                    name="ssn_rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+        )
+        cc_policy = Policy(
+            name="CC Policy",
+            detection_rules=[
+                DetectionRule(
+                    name="cc_rule",
+                    conditions=[RuleCondition(analyzer_name="cc")],
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(ssn_policy)
+        evaluator.add_policy(cc_policy)
+
+        result = evaluator.evaluate_with_result(_make_message(), detection)
+        assert result.has_violations
+        assert result.triggered_policies == ["SSN Policy"]
+
+        ssn_v = [v for v in result.violations if v.policy_name == "SSN Policy"][0]
+        cc_v = [v for v in result.violations if v.policy_name == "CC Policy"][0]
+        assert ssn_v.triggered is True
+        assert cc_v.triggered is False
+
+    def test_mco_condition_false_does_not_filter(self):
+        """MCO exception whose condition returns False → matches preserved."""
+        match = _make_match(analyzer_name="ssn", component_type=ComponentType.BODY)
+        detection = _make_detection([match])
+
+        policy = Policy(
+            name="test",
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            exceptions=[
+                PolicyException(
+                    name="inactive_mco",
+                    scope=ExceptionScope.COMPONENT,
+                    component_types=[ComponentType.BODY],
+                    analyzer_names=["ssn"],
+                    condition=lambda msg, det: False,  # does NOT apply
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        result = evaluator.evaluate_with_result(_make_message(), detection)
+        v = result.violations[0]
+        assert v.triggered
+        assert v.match_count == 1
+        assert "inactive_mco" not in v.exceptions_applied
+
+    def test_not_matches_in_compound_rule(self):
+        """Compound: keyword present AND no SSN → triggers only for that combo."""
+        kw_match = _make_match(analyzer_name="kw")
+        detection_kw_only = _make_detection([kw_match])
+
+        rule = DetectionRule(
+            name="kw_without_ssn",
+            conditions=[
+                RuleCondition(analyzer_name="kw"),
+                RuleCondition(
+                    analyzer_name="ssn",
+                    operator=ConditionOperator.NOT_MATCHES,
+                ),
+            ],
+        )
+
+        policy = Policy(name="test", detection_rules=[rule])
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        # keyword present, no SSN → triggers
+        result = evaluator.evaluate_with_result(_make_message(), detection_kw_only)
+        assert result.has_violations
+
+        # keyword + SSN present → does NOT trigger (NOT_MATCHES fails)
+        detection_both = _make_detection([
+            _make_match(analyzer_name="kw"),
+            _make_match(analyzer_name="ssn"),
+        ])
+        result2 = evaluator.evaluate_with_result(_make_message(), detection_both)
+        assert not result2.has_violations
+
+    def test_domain_exception_with_real_engine(self):
+        """Integration: domain-based exception with real detection."""
+        engine = _ssn_engine()
+
+        policy = Policy(
+            name="PII Policy",
+            detection_rules=[
+                DetectionRule(
+                    name="ssn_rule",
+                    conditions=[RuleCondition(analyzer_name="ssn_regex")],
+                )
+            ],
+            exceptions=[
+                PolicyException(
+                    name="Internal Domain",
+                    scope=ExceptionScope.ENTIRE_MESSAGE,
+                    groups=[
+                        SenderRecipientGroup(
+                            name="Internal",
+                            members=["company.com"],
+                            match_mode=GroupMatchMode.DOMAIN,
+                            field="sender",
+                        )
+                    ],
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator(engine)
+        evaluator.add_policy(policy)
+
+        # Internal sender → no incident
+        msg1 = _make_message(sender="hr@company.com", body="SSN: 123-45-6789")
+        assert not evaluator.evaluate(msg1).has_violations
+
+        # External sender → incident
+        msg2 = _make_message(sender="user@external.com", body="SSN: 123-45-6789")
+        assert evaluator.evaluate(msg2).has_violations
+
+    def test_or_with_compound_rules(self):
+        """OR across two compound AND rules: either compound triggers."""
+        detection = _make_detection([
+            _make_match(analyzer_name="cc"),
+            _make_match(analyzer_name="ft"),
+        ])
+
+        policy = Policy(
+            name="test",
+            detection_rules=[
+                # Rule 1: SSN AND keyword (won't match — no SSN)
+                DetectionRule(
+                    name="ssn_kw",
+                    conditions=[
+                        RuleCondition(analyzer_name="ssn"),
+                        RuleCondition(analyzer_name="kw"),
+                    ],
+                ),
+                # Rule 2: CC AND file type (will match)
+                DetectionRule(
+                    name="cc_ft",
+                    conditions=[
+                        RuleCondition(analyzer_name="cc"),
+                        RuleCondition(analyzer_name="ft"),
+                    ],
+                ),
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        result = evaluator.evaluate_with_result(_make_message(), detection)
+        assert result.has_violations
+        v = result.violations[0]
+        assert "cc_ft" in v.matched_rules
+        assert "ssn_kw" not in v.matched_rules
+
+    def test_group_with_recipients_field(self):
+        """Group constraint on recipients field with domain matching."""
+        matches = [_make_match(analyzer_name="ssn")]
+        detection = _make_detection(matches)
+
+        policy = Policy(
+            name="External Recipients",
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            groups=[
+                SenderRecipientGroup(
+                    name="External",
+                    members=["partner.com", "vendor.com"],
+                    match_mode=GroupMatchMode.DOMAIN,
+                    field="recipients",
+                )
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        # Internal recipients only → no violation
+        msg1 = _make_message(recipients=["user@company.com"])
+        assert not evaluator.evaluate_with_result(msg1, detection).has_violations
+
+        # One external recipient → violation
+        msg2 = _make_message(
+            recipients=["user@company.com", "partner@partner.com"]
+        )
+        assert evaluator.evaluate_with_result(msg2, detection).has_violations
+
+    def test_large_match_set_performance(self):
+        """Evaluate with 1000 matches — should complete quickly."""
+        matches = [_make_match(analyzer_name="ssn") for _ in range(1000)]
+        detection = _make_detection(matches)
+
+        policy = Policy(
+            name="bulk",
+            detection_rules=[
+                DetectionRule(
+                    name="rule",
+                    conditions=[RuleCondition(analyzer_name="ssn")],
+                )
+            ],
+            severity_levels=[
+                SeverityLevel(severity=Severity.LOW, min_matches=1),
+                SeverityLevel(severity=Severity.MEDIUM, min_matches=100),
+                SeverityLevel(severity=Severity.HIGH, min_matches=500),
+                SeverityLevel(severity=Severity.CRITICAL, min_matches=1000),
+            ],
+        )
+
+        evaluator = PolicyEvaluator()
+        evaluator.add_policy(policy)
+
+        result = evaluator.evaluate_with_result(_make_message(), detection)
+        v = result.violations[0]
+        assert v.triggered
+        assert v.match_count == 1000
+        assert v.severity == Severity.CRITICAL


### PR DESCRIPTION
## Summary
- **PolicyEvaluator** implementing full Symantec 16.0-style policy evaluation: compound rules (AND within conditions, OR across rules), sender/recipient group constraints (AND with detection), exception evaluation (entire-message then MCO), and severity calculation with match count thresholds
- Data models: `Policy`, `DetectionRule`, `RuleCondition`, `SenderRecipientGroup`, `PolicyException`, `SeverityLevel`, `PolicyViolation`, `EvaluationResult`
- Supports exact, domain, and regex group matching; custom exception conditions; disabled policies; multi-policy independent evaluation
- **67 tests** covering all acceptance criteria plus adversarial robustness (MCO stacking, boundary values, NOT_MATCHES compound, 1000-match performance)

## Acceptance Criteria
- ✅ Compound rule (keyword AND file type): both match → incident, one misses → no incident
- ✅ Exception for sender → no incident
- ✅ Severity tiers: 3 matches → Medium, 10 → High
- ✅ MCO exception removes only matched component, not entire message

## Test plan
- [x] 67 new tests in `test_policy_evaluator.py`
- [x] Full detection suite: 355 tests passing
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)