### PR TITLE
Fix server Dockerfile: use python-magic for Linux compatibility

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,13 +1,15 @@
 FROM python:3.12-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    postgresql-client wget \
+    postgresql-client wget libmagic1 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN sed -i '/python-magic-bin/d' requirements.txt && \
+    pip install --no-cache-dir python-magic && \
+    pip install --no-cache-dir -r requirements.txt
 
 COPY scripts/wait-for-db.sh /usr/local/bin/wait-for-db
 RUN chmod +x /usr/local/bin/wait-for-db


### PR DESCRIPTION
## Summary
- `python-magic-bin` has no Linux wheels — Docker builds fail with `No matching distribution found`
- Replaced with `python-magic` + system `libmagic1` package for Linux containers
- `python-magic-bin` stripped from requirements.txt at build time (still used locally on Windows)

## Test plan
- [x] `docker compose up --build` starts successfully
- [x] `/api/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)