### PR TITLE
Add Policy CRUD endpoints with audit logging (P2-T2)

### DIFF
--- a/server/api/policies.py
+++ b/server/api/policies.py
@@ -1,0 +1,443 @@
+"""Policy CRUD API endpoints (P2-T2).
+
+Endpoints:
+  GET    /api/policies              — List policies (paginated, filterable)
+  POST   /api/policies              — Create policy
+  GET    /api/policies/{id}         — Get policy detail
+  PUT    /api/policies/{id}         — Update policy
+  DELETE /api/policies/{id}         — Delete policy
+  POST   /api/policies/{id}/activate  — Activate policy
+  POST   /api/policies/{id}/suspend   — Suspend policy
+  POST   /api/policies/{id}/rules     — Add detection rule
+  DELETE /api/policies/{id}/rules/{rule_id} — Remove detection rule
+  POST   /api/policies/{id}/exceptions     — Add exception
+  DELETE /api/policies/{id}/exceptions/{exc_id} — Remove exception
+  GET    /api/policies/templates       — List templates
+  POST   /api/policies/from-template   — Create from template
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.api.dependencies import (
+    CurrentUser,
+    RequirePermission,
+    get_client_ip,
+)
+from server.database import get_db
+from server.schemas.policy import (
+    DetectionRuleCreate,
+    DetectionRuleResponse,
+    PolicyCreate,
+    PolicyExceptionCreate,
+    PolicyExceptionResponse,
+    PolicyListResponse,
+    PolicyResponse,
+    PolicyUpdate,
+)
+from server.services import policy_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/policies", tags=["policies"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _policy_or_404(policy):
+    """Raise 404 if policy is None."""
+    if policy is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        )
+    return policy
+
+
+async def _audit(
+    db: AsyncSession,
+    user: CurrentUser,
+    action: str,
+    request: Request,
+    resource_id: str | None = None,
+    detail: str | None = None,
+    changes: dict | None = None,
+):
+    """Helper to create an audit log entry."""
+    await policy_service.create_audit_entry(
+        db,
+        actor_id=user.id,
+        action=action,
+        resource_id=resource_id,
+        detail=detail,
+        changes=changes,
+        ip_address=get_client_ip(request),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Templates (before {id} routes to avoid path conflicts)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/templates", response_model=list[PolicyResponse])
+async def list_templates(
+    user: CurrentUser = Depends(RequirePermission("policies:read")),
+    db: AsyncSession = Depends(get_db),
+):
+    """List all available policy templates."""
+    templates = await policy_service.list_templates(db)
+    return templates
+
+
+from pydantic import BaseModel, Field  # noqa: E402
+
+
+class FromTemplateRequest(BaseModel):
+    template_name: str = Field(max_length=100)
+    name: str = Field(max_length=255)
+    description: str | None = None
+
+
+@router.post("/from-template", response_model=PolicyResponse, status_code=status.HTTP_201_CREATED)
+async def create_from_template(
+    body: FromTemplateRequest,
+    request: Request,
+    user: CurrentUser = Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new policy from an existing template."""
+    template = await policy_service.get_template(db, body.template_name)
+    if template is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Template '{body.template_name}' not found",
+        )
+
+    policy = await policy_service.create_from_template(
+        db, template, body.name, body.description
+    )
+    await _audit(
+        db, user, "policy.create_from_template", request,
+        resource_id=str(policy.id),
+        detail=f"Created from template '{body.template_name}'",
+        changes={"template_name": body.template_name, "name": body.name},
+    )
+    await db.commit()
+    return policy
+
+
+# ---------------------------------------------------------------------------
+# Policy CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=PolicyListResponse)
+async def list_policies(
+    user: CurrentUser = Depends(RequirePermission("policies:read")),
+    db: AsyncSession = Depends(get_db),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=25, ge=1, le=100),
+    status_filter: str | None = Query(default=None, alias="status"),
+    search: str | None = Query(default=None),
+):
+    """List policies with pagination and optional filters."""
+    policies, total = await policy_service.list_policies(
+        db, page=page, page_size=page_size,
+        status_filter=status_filter, search=search,
+    )
+    return PolicyListResponse(
+        items=policies,
+        total=total,
+        page=page,
+        page_size=page_size,
+        pages=max(1, math.ceil(total / page_size)),
+    )
+
+
+@router.post("", response_model=PolicyResponse, status_code=status.HTTP_201_CREATED)
+async def create_policy(
+    body: PolicyCreate,
+    request: Request,
+    user: CurrentUser = Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new policy with optional detection rules and exceptions."""
+    data = body.model_dump()
+    policy = await policy_service.create_policy(db, data)
+    await _audit(
+        db, user, "policy.create", request,
+        resource_id=str(policy.id),
+        detail=f"Created policy '{body.name}'",
+        changes={"name": body.name},
+    )
+    await db.commit()
+    return policy
+
+
+@router.get("/{policy_id}", response_model=PolicyResponse)
+async def get_policy(
+    policy_id: uuid.UUID,
+    user: CurrentUser = Depends(RequirePermission("policies:read")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get a single policy by ID."""
+    policy = await policy_service.get_policy(db, policy_id)
+    return _policy_or_404(policy)
+
+
+@router.put("/{policy_id}", response_model=PolicyResponse)
+async def update_policy(
+    policy_id: uuid.UUID,
+    body: PolicyUpdate,
+    request: Request,
+    user: CurrentUser = Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update policy metadata (name, description, severity, etc.)."""
+    policy = await policy_service.get_policy(db, policy_id)
+    _policy_or_404(policy)
+
+    update_data = body.model_dump(exclude_unset=True)
+    if not update_data:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No fields to update",
+        )
+
+    old_values = {k: getattr(policy, k) for k in update_data}
+    policy = await policy_service.update_policy(db, policy, update_data)
+    await _audit(
+        db, user, "policy.update", request,
+        resource_id=str(policy.id),
+        detail=f"Updated policy '{policy.name}'",
+        changes={"old": _serialize_changes(old_values), "new": _serialize_changes(update_data)},
+    )
+    await db.commit()
+    return policy
+
+
+@router.delete("/{policy_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_policy(
+    policy_id: uuid.UUID,
+    request: Request,
+    user: CurrentUser = Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a policy and all related entities."""
+    policy = await policy_service.get_policy(db, policy_id)
+    _policy_or_404(policy)
+
+    name = policy.name
+    await policy_service.delete_policy(db, policy)
+    await _audit(
+        db, user, "policy.delete", request,
+        resource_id=str(policy_id),
+        detail=f"Deleted policy '{name}'",
+    )
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Activate / Suspend
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{policy_id}/activate", response_model=PolicyResponse)
+async def activate_policy(
+    policy_id: uuid.UUID,
+    request: Request,
+    user: CurrentUser = Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Activate a policy."""
+    policy = await policy_service.get_policy(db, policy_id)
+    _policy_or_404(policy)
+
+    old_status = policy.status.value
+    policy = await policy_service.activate_policy(db, policy)
+    await _audit(
+        db, user, "policy.activate", request,
+        resource_id=str(policy_id),
+        detail=f"Activated policy '{policy.name}'",
+        changes={"old_status": old_status, "new_status": "active"},
+    )
+    await db.commit()
+    return policy
+
+
+@router.post("/{policy_id}/suspend", response_model=PolicyResponse)
+async def suspend_policy(
+    policy_id: uuid.UUID,
+    request: Request,
+    user: CurrentUser = Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Suspend a policy."""
+    policy = await policy_service.get_policy(db, policy_id)
+    _policy_or_404(policy)
+
+    old_status = policy.status.value
+    policy = await policy_service.suspend_policy(db, policy)
+    await _audit(
+        db, user, "policy.suspend", request,
+        resource_id=str(policy_id),
+        detail=f"Suspended policy '{policy.name}'",
+        changes={"old_status": old_status, "new_status": "suspended"},
+    )
+    await db.commit()
+    return policy
+
+
+# ---------------------------------------------------------------------------
+# Rule management
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{policy_id}/rules", response_model=DetectionRuleResponse, status_code=status.HTTP_201_CREATED)
+async def add_rule(
+    policy_id: uuid.UUID,
+    body: DetectionRuleCreate,
+    request: Request,
+    user: CurrentUser = Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Add a detection rule to a policy."""
+    policy = await policy_service.get_policy(db, policy_id)
+    _policy_or_404(policy)
+
+    data = body.model_dump()
+    rule = await policy_service.add_rule(db, policy, data)
+    await _audit(
+        db, user, "policy.add_rule", request,
+        resource_id=str(policy_id),
+        detail=f"Added rule '{body.name}' to policy '{policy.name}'",
+        changes={"rule_name": body.name},
+    )
+    await db.commit()
+    return rule
+
+
+@router.delete("/{policy_id}/rules/{rule_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_rule(
+    policy_id: uuid.UUID,
+    rule_id: uuid.UUID,
+    request: Request,
+    user: CurrentUser = Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Remove a detection rule from a policy."""
+    # Verify policy exists
+    policy = await policy_service.get_policy(db, policy_id)
+    _policy_or_404(policy)
+
+    deleted = await policy_service.remove_rule(db, rule_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Rule not found",
+        )
+
+    await _audit(
+        db, user, "policy.remove_rule", request,
+        resource_id=str(policy_id),
+        detail=f"Removed rule {rule_id} from policy '{policy.name}'",
+        changes={"rule_id": str(rule_id)},
+    )
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Exception management
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{policy_id}/exceptions",
+    response_model=PolicyExceptionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_exception(
+    policy_id: uuid.UUID,
+    body: PolicyExceptionCreate,
+    request: Request,
+    user: CurrentUser = Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Add an exception to a policy."""
+    policy = await policy_service.get_policy(db, policy_id)
+    _policy_or_404(policy)
+
+    data = body.model_dump()
+    exc = await policy_service.add_exception(db, policy, data)
+    await _audit(
+        db, user, "policy.add_exception", request,
+        resource_id=str(policy_id),
+        detail=f"Added exception '{body.name}' to policy '{policy.name}'",
+        changes={"exception_name": body.name},
+    )
+    await db.commit()
+    return exc
+
+
+@router.delete(
+    "/{policy_id}/exceptions/{exception_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def remove_exception(
+    policy_id: uuid.UUID,
+    exception_id: uuid.UUID,
+    request: Request,
+    user: CurrentUser = Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Remove an exception from a policy."""
+    policy = await policy_service.get_policy(db, policy_id)
+    _policy_or_404(policy)
+
+    deleted = await policy_service.remove_exception(db, exception_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Exception not found",
+        )
+
+    await _audit(
+        db, user, "policy.remove_exception", request,
+        resource_id=str(policy_id),
+        detail=f"Removed exception {exception_id} from policy '{policy.name}'",
+        changes={"exception_id": str(exception_id)},
+    )
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _serialize_changes(d: dict) -> dict:
+    """Convert non-serializable values to strings for audit log JSONB."""
+    result = {}
+    for k, v in d.items():
+        if isinstance(v, uuid.UUID):
+            result[k] = str(v)
+        elif hasattr(v, "value"):  # Enum
+            result[k] = v.value
+        elif isinstance(v, list):
+            result[k] = [
+                t if isinstance(t, dict) else {"threshold": t.threshold, "severity": t.severity}
+                for t in v
+            ] if v else []
+        else:
+            result[k] = v
+    return result

--- a/server/main.py
+++ b/server/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from server.config import settings
 from server.api.auth import router as auth_router
+from server.api.policies import router as policies_router
 
 
 @asynccontextmanager
@@ -31,6 +32,7 @@ app.add_middleware(
 
 # --- Routers ---
 app.include_router(auth_router)
+app.include_router(policies_router)
 
 
 @app.get("/api/health")

--- a/server/services/policy_service.py
+++ b/server/services/policy_service.py
@@ -1,0 +1,399 @@
+"""Policy service — CRUD operations for policies and related entities.
+
+Provides database operations for the full policy lifecycle:
+create, read, update, delete, activate/suspend, and template cloning.
+All mutations are audit-logged.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from server.models.audit import AuditLog
+from server.models.policy import (
+    DetectionRule,
+    ExceptionCondition,
+    Policy,
+    PolicyException,
+    PolicyStatus,
+    RuleCondition,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Eager-loading options (avoid N+1)
+# ---------------------------------------------------------------------------
+
+_POLICY_LOAD_OPTIONS = [
+    selectinload(Policy.group),
+    selectinload(Policy.detection_rules).selectinload(DetectionRule.conditions),
+    selectinload(Policy.exceptions).selectinload(PolicyException.conditions),
+]
+
+
+# ---------------------------------------------------------------------------
+# Policy CRUD
+# ---------------------------------------------------------------------------
+
+
+async def get_policy(db: AsyncSession, policy_id: uuid.UUID) -> Policy | None:
+    """Fetch a single policy by ID with all nested relationships."""
+    stmt = (
+        select(Policy)
+        .where(Policy.id == policy_id, Policy.is_template == False)  # noqa: E712
+        .options(*_POLICY_LOAD_OPTIONS)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_policies(
+    db: AsyncSession,
+    *,
+    page: int = 1,
+    page_size: int = 25,
+    status_filter: str | None = None,
+    search: str | None = None,
+) -> tuple[list[Policy], int]:
+    """List non-template policies with pagination and optional filters.
+
+    Returns (policies, total_count).
+    """
+    base = select(Policy).where(Policy.is_template == False)  # noqa: E712
+
+    if status_filter:
+        base = base.where(Policy.status == PolicyStatus(status_filter))
+
+    if search:
+        base = base.where(Policy.name.ilike(f"%{search}%"))
+
+    # Total count
+    count_stmt = select(func.count()).select_from(base.subquery())
+    total = (await db.execute(count_stmt)).scalar() or 0
+
+    # Paginated results
+    offset = (page - 1) * page_size
+    stmt = (
+        base.options(*_POLICY_LOAD_OPTIONS)
+        .order_by(Policy.created_at.desc())
+        .offset(offset)
+        .limit(page_size)
+    )
+    result = await db.execute(stmt)
+    policies = list(result.scalars().all())
+
+    return policies, total
+
+
+async def create_policy(
+    db: AsyncSession,
+    data: dict[str, Any],
+) -> Policy:
+    """Create a new policy with nested rules and exceptions."""
+    rules_data = data.pop("detection_rules", [])
+    exceptions_data = data.pop("exceptions", [])
+
+    # Handle severity_thresholds — normalize to list of dicts
+    thresholds = data.get("severity_thresholds")
+    if thresholds is not None:
+        # Could be: JSON string, list of dicts, or list of Pydantic models
+        if isinstance(thresholds, str):
+            import json
+            thresholds = json.loads(thresholds)
+        data["severity_thresholds"] = [
+            t if isinstance(t, dict) else {"threshold": t.threshold, "severity": t.severity}
+            for t in thresholds
+        ]
+
+    policy = Policy(**data)
+    db.add(policy)
+    await db.flush()  # Get policy.id
+
+    # Add detection rules with conditions
+    for rule_data in rules_data:
+        conditions_data = rule_data.pop("conditions", [])
+        rule = DetectionRule(policy_id=policy.id, **rule_data)
+        db.add(rule)
+        await db.flush()
+
+        for cond_data in conditions_data:
+            condition = RuleCondition(detection_rule_id=rule.id, **cond_data)
+            db.add(condition)
+
+    # Add exceptions with conditions
+    for exc_data in exceptions_data:
+        conditions_data = exc_data.pop("conditions", [])
+        exc = PolicyException(policy_id=policy.id, **exc_data)
+        db.add(exc)
+        await db.flush()
+
+        for cond_data in conditions_data:
+            condition = ExceptionCondition(policy_exception_id=exc.id, **cond_data)
+            db.add(condition)
+
+    await db.flush()
+
+    # Reload with relationships
+    return await get_policy(db, policy.id)
+
+
+async def update_policy(
+    db: AsyncSession,
+    policy: Policy,
+    data: dict[str, Any],
+) -> Policy:
+    """Update policy scalar fields (not nested rules/exceptions)."""
+    # Handle severity_thresholds serialization
+    thresholds = data.get("severity_thresholds")
+    if thresholds is not None:
+        if isinstance(thresholds, str):
+            import json
+            thresholds = json.loads(thresholds)
+        data["severity_thresholds"] = [
+            t if isinstance(t, dict) else {"threshold": t.threshold, "severity": t.severity}
+            for t in thresholds
+        ]
+
+    for key, value in data.items():
+        if value is not None:
+            setattr(policy, key, value)
+
+    await db.flush()
+    return await get_policy(db, policy.id)
+
+
+async def delete_policy(db: AsyncSession, policy: Policy) -> None:
+    """Delete a policy and all cascade-related entities."""
+    await db.delete(policy)
+    await db.flush()
+
+
+async def activate_policy(db: AsyncSession, policy: Policy) -> Policy:
+    """Set policy status to active."""
+    policy.status = PolicyStatus.ACTIVE
+    await db.flush()
+    return await get_policy(db, policy.id)
+
+
+async def suspend_policy(db: AsyncSession, policy: Policy) -> Policy:
+    """Set policy status to suspended."""
+    policy.status = PolicyStatus.SUSPENDED
+    await db.flush()
+    return await get_policy(db, policy.id)
+
+
+# ---------------------------------------------------------------------------
+# Template operations
+# ---------------------------------------------------------------------------
+
+
+async def get_template(db: AsyncSession, template_name: str) -> Policy | None:
+    """Fetch a policy template by template_name."""
+    stmt = (
+        select(Policy)
+        .where(Policy.is_template == True, Policy.template_name == template_name)  # noqa: E712
+        .options(*_POLICY_LOAD_OPTIONS)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_templates(db: AsyncSession) -> list[Policy]:
+    """List all available policy templates."""
+    stmt = (
+        select(Policy)
+        .where(Policy.is_template == True)  # noqa: E712
+        .options(*_POLICY_LOAD_OPTIONS)
+        .order_by(Policy.name)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def create_from_template(
+    db: AsyncSession,
+    template: Policy,
+    name: str,
+    description: str | None = None,
+) -> Policy:
+    """Clone a template into a new draft policy.
+
+    Deep-copies detection rules, conditions, exceptions, and severity
+    thresholds from the template. The new policy is always DRAFT.
+    """
+    policy_data = {
+        "name": name,
+        "description": description or template.description,
+        "severity": template.severity,
+        "severity_thresholds": template.severity_thresholds,
+        "ttd_fallback": template.ttd_fallback,
+        "group_id": template.group_id,
+        "response_rule_id": template.response_rule_id,
+    }
+
+    rules_data = []
+    for rule in template.detection_rules:
+        rule_dict = {
+            "name": rule.name,
+            "description": rule.description,
+            "rule_type": rule.rule_type,
+            "conditions": [
+                {
+                    "condition_type": c.condition_type,
+                    "component": c.component,
+                    "config": c.config,
+                    "match_count_min": c.match_count_min,
+                }
+                for c in rule.conditions
+            ],
+        }
+        rules_data.append(rule_dict)
+
+    exceptions_data = []
+    for exc in template.exceptions:
+        exc_dict = {
+            "name": exc.name,
+            "description": exc.description,
+            "scope": exc.scope,
+            "exception_type": exc.exception_type,
+            "conditions": [
+                {
+                    "condition_type": c.condition_type,
+                    "component": c.component,
+                    "config": c.config,
+                    "match_count_min": c.match_count_min,
+                }
+                for c in exc.conditions
+            ],
+        }
+        exceptions_data.append(exc_dict)
+
+    policy_data["detection_rules"] = rules_data
+    policy_data["exceptions"] = exceptions_data
+
+    return await create_policy(db, policy_data)
+
+
+# ---------------------------------------------------------------------------
+# Detection rule management (add/remove rules on existing policies)
+# ---------------------------------------------------------------------------
+
+
+async def add_rule(
+    db: AsyncSession,
+    policy: Policy,
+    data: dict[str, Any],
+) -> DetectionRule:
+    """Add a detection rule with conditions to an existing policy."""
+    conditions_data = data.pop("conditions", [])
+    rule = DetectionRule(policy_id=policy.id, **data)
+    db.add(rule)
+    await db.flush()
+
+    for cond_data in conditions_data:
+        condition = RuleCondition(detection_rule_id=rule.id, **cond_data)
+        db.add(condition)
+
+    await db.flush()
+
+    # Reload rule with conditions
+    stmt = (
+        select(DetectionRule)
+        .where(DetectionRule.id == rule.id)
+        .options(selectinload(DetectionRule.conditions))
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one()
+
+
+async def remove_rule(db: AsyncSession, rule_id: uuid.UUID) -> bool:
+    """Remove a detection rule by ID. Returns True if found and deleted."""
+    stmt = select(DetectionRule).where(DetectionRule.id == rule_id)
+    result = await db.execute(stmt)
+    rule = result.scalar_one_or_none()
+    if rule is None:
+        return False
+    await db.delete(rule)
+    await db.flush()
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Exception management
+# ---------------------------------------------------------------------------
+
+
+async def add_exception(
+    db: AsyncSession,
+    policy: Policy,
+    data: dict[str, Any],
+) -> PolicyException:
+    """Add an exception with conditions to an existing policy."""
+    conditions_data = data.pop("conditions", [])
+    exc = PolicyException(policy_id=policy.id, **data)
+    db.add(exc)
+    await db.flush()
+
+    for cond_data in conditions_data:
+        condition = ExceptionCondition(policy_exception_id=exc.id, **cond_data)
+        db.add(condition)
+
+    await db.flush()
+
+    stmt = (
+        select(PolicyException)
+        .where(PolicyException.id == exc.id)
+        .options(selectinload(PolicyException.conditions))
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one()
+
+
+async def remove_exception(db: AsyncSession, exception_id: uuid.UUID) -> bool:
+    """Remove a policy exception by ID. Returns True if found and deleted."""
+    stmt = select(PolicyException).where(PolicyException.id == exception_id)
+    result = await db.execute(stmt)
+    exc = result.scalar_one_or_none()
+    if exc is None:
+        return False
+    await db.delete(exc)
+    await db.flush()
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Audit logging
+# ---------------------------------------------------------------------------
+
+
+async def create_audit_entry(
+    db: AsyncSession,
+    *,
+    actor_id: uuid.UUID,
+    action: str,
+    resource_id: str | None = None,
+    detail: str | None = None,
+    changes: dict | None = None,
+    ip_address: str | None = None,
+) -> AuditLog:
+    """Record an audit log entry for a policy mutation."""
+    entry = AuditLog(
+        actor_id=actor_id,
+        action=action,
+        resource_type="policy",
+        resource_id=resource_id,
+        detail=detail,
+        changes=changes,
+        ip_address=ip_address,
+    )
+    db.add(entry)
+    await db.flush()
+    return entry

--- a/tests/api/test_policies.py
+++ b/tests/api/test_policies.py
@@ -1,0 +1,981 @@
+"""Tests for policy CRUD endpoints (P2-T2).
+
+Covers: list, create, get, update, delete, activate/suspend,
+template creation, rule/exception management, audit logging,
+and RBAC permission enforcement.
+
+Uses SQLite in-memory database with type compilation for
+PostgreSQL-specific types (UUID, JSONB).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from server.api.dependencies import login_rate_limiter
+from server.database import get_db
+from server.main import app
+from server.models.audit import AuditLog
+from server.models.auth import Role, User
+from server.models.base import Base
+from server.models.policy import (
+    DetectionRule,
+    Policy,
+    PolicyGroup,
+    PolicyStatus,
+    RuleCondition,
+    Severity,
+)
+from server.services import auth_service
+
+# ---------------------------------------------------------------------------
+# SQLite ↔ PostgreSQL type compilation
+# ---------------------------------------------------------------------------
+
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
+
+
+# Compile JSONB → TEXT for SQLite
+@event.listens_for(Base.metadata, "before_create")
+def _compile_pg_types(target, connection, **kw):
+    """Register PostgreSQL type compilers for SQLite."""
+    pass
+
+
+# We need compile-time adapters. SQLAlchemy's visit methods handle this.
+from sqlalchemy.ext.compiler import compiles  # noqa: E402
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_sqlite(type_, compiler, **kw):
+    return "TEXT"
+
+
+@compiles(PG_UUID, "sqlite")
+def _compile_uuid_sqlite(type_, compiler, **kw):
+    return "VARCHAR(36)"
+
+
+# ---------------------------------------------------------------------------
+# Test database setup
+# ---------------------------------------------------------------------------
+
+TEST_DB_URL = "sqlite+aiosqlite:///file::memory:?cache=shared&uri=true"
+
+test_engine = create_async_engine(TEST_DB_URL, echo=False)
+TestSessionLocal = async_sessionmaker(
+    test_engine, class_=AsyncSession, expire_on_commit=False
+)
+
+
+@event.listens_for(test_engine.sync_engine, "connect")
+def _set_sqlite_pragma(dbapi_conn, connection_record):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA journal_mode=WAL")
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+async def override_get_db():
+    async with TestSessionLocal() as session:
+        yield session
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+# Tables needed for policy tests
+POLICY_TABLES = [
+    Base.metadata.tables["roles"],
+    Base.metadata.tables["users"],
+    Base.metadata.tables["sessions"],
+    Base.metadata.tables["policy_groups"],
+    Base.metadata.tables["response_rules"],
+    Base.metadata.tables["response_actions"],
+    Base.metadata.tables["policies"],
+    Base.metadata.tables["detection_rules"],
+    Base.metadata.tables["rule_conditions"],
+    Base.metadata.tables["policy_exceptions"],
+    Base.metadata.tables["exception_conditions"],
+    Base.metadata.tables["audit_log"],
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def setup_db():
+    """Create tables, seed roles/users/templates, drop after test."""
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all, tables=POLICY_TABLES)
+
+    async with TestSessionLocal() as db:
+        # Roles
+        admin_role = Role(id=uuid.uuid4(), name="Admin", description="Full access")
+        analyst_role = Role(id=uuid.uuid4(), name="Analyst", description="Read only")
+        db.add_all([admin_role, analyst_role])
+        await db.flush()
+
+        # Users
+        admin_user = User(
+            id=uuid.uuid4(),
+            username="admin",
+            email="admin@sentinel.local",
+            password_hash=auth_service.hash_password("SentinelDLP2026!"),
+            full_name="Admin User",
+            is_active=True,
+            mfa_enabled=False,
+            role_id=admin_role.id,
+        )
+        analyst_user = User(
+            id=uuid.uuid4(),
+            username="analyst",
+            email="analyst@sentinel.local",
+            password_hash=auth_service.hash_password("AnalystPass123!"),
+            full_name="Analyst User",
+            is_active=True,
+            mfa_enabled=False,
+            role_id=analyst_role.id,
+        )
+        db.add_all([admin_user, analyst_user])
+        await db.flush()
+
+        # Policy group for templates
+        template_group = PolicyGroup(
+            id=uuid.uuid4(), name="Built-in Templates", description="Seed templates"
+        )
+        db.add(template_group)
+        await db.flush()
+
+        # PCI-DSS template
+        pci_template = Policy(
+            id=uuid.uuid4(),
+            name="PCI-DSS Compliance",
+            description="Payment card data protection",
+            status=PolicyStatus.SUSPENDED,
+            severity=Severity.HIGH,
+            is_template=True,
+            template_name="pci_dss",
+            severity_thresholds=[
+                {"threshold": 1, "severity": "medium"},
+                {"threshold": 5, "severity": "high"},
+                {"threshold": 10, "severity": "critical"},
+            ],
+            ttd_fallback="block",
+            group_id=template_group.id,
+        )
+        db.add(pci_template)
+        await db.flush()
+
+        # Template detection rule
+        pci_rule = DetectionRule(
+            id=uuid.uuid4(),
+            name="Credit Card Detection",
+            description="Detect credit card numbers",
+            rule_type="detection",
+            policy_id=pci_template.id,
+        )
+        db.add(pci_rule)
+        await db.flush()
+
+        pci_condition = RuleCondition(
+            id=uuid.uuid4(),
+            condition_type="data_identifier",
+            component="generic",
+            config={"identifier_name": "credit_card_number"},
+            match_count_min=1,
+            detection_rule_id=pci_rule.id,
+        )
+        db.add(pci_condition)
+        await db.commit()
+
+    yield
+
+    login_rate_limiter._buckets.clear()
+
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all, tables=POLICY_TABLES)
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def admin_token(client: AsyncClient) -> str:
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "SentinelDLP2026!"},
+    )
+    return resp.json()["access_token"]
+
+
+@pytest_asyncio.fixture
+async def analyst_token(client: AsyncClient) -> str:
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "analyst", "password": "AnalystPass123!"},
+    )
+    return resp.json()["access_token"]
+
+
+def auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Helper: create a policy via API
+# ---------------------------------------------------------------------------
+
+
+async def _create_policy(
+    client: AsyncClient,
+    token: str,
+    name: str = "Test Policy",
+    description: str = "A test policy",
+    **kwargs,
+) -> dict:
+    """Helper to create a policy and return the JSON response."""
+    body = {
+        "name": name,
+        "description": description,
+        "severity": kwargs.get("severity", "medium"),
+        "ttd_fallback": kwargs.get("ttd_fallback", "log"),
+        "detection_rules": kwargs.get("detection_rules", []),
+        "exceptions": kwargs.get("exceptions", []),
+    }
+    if "severity_thresholds" in kwargs:
+        body["severity_thresholds"] = kwargs["severity_thresholds"]
+    resp = await client.post("/api/policies", json=body, headers=auth(token))
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+class TestListPolicies:
+    @pytest.mark.asyncio
+    async def test_list_empty(self, client, admin_token):
+        """List policies returns empty when no non-template policies exist."""
+        resp = await client.get("/api/policies", headers=auth(admin_token))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 0
+        assert data["items"] == []
+        assert data["page"] == 1
+
+    @pytest.mark.asyncio
+    async def test_list_with_policies(self, client, admin_token):
+        """List returns created policies (not templates)."""
+        await _create_policy(client, admin_token, name="Policy A")
+        await _create_policy(client, admin_token, name="Policy B")
+
+        resp = await client.get("/api/policies", headers=auth(admin_token))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 2
+        assert len(data["items"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_pagination(self, client, admin_token):
+        """Pagination works with page and page_size."""
+        for i in range(5):
+            await _create_policy(client, admin_token, name=f"Policy {i}")
+
+        resp = await client.get(
+            "/api/policies?page=1&page_size=2", headers=auth(admin_token)
+        )
+        data = resp.json()
+        assert data["total"] == 5
+        assert len(data["items"]) == 2
+        assert data["pages"] == 3
+
+    @pytest.mark.asyncio
+    async def test_list_status_filter(self, client, admin_token):
+        """Filter by status works."""
+        policy = await _create_policy(client, admin_token, name="Draft Policy")
+        # Activate it
+        pid = policy["id"]
+        await client.post(f"/api/policies/{pid}/activate", headers=auth(admin_token))
+
+        resp = await client.get(
+            "/api/policies?status=active", headers=auth(admin_token)
+        )
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["items"][0]["name"] == "Draft Policy"
+
+    @pytest.mark.asyncio
+    async def test_list_search(self, client, admin_token):
+        """Search by name substring works."""
+        await _create_policy(client, admin_token, name="PCI Policy")
+        await _create_policy(client, admin_token, name="HIPAA Policy")
+
+        resp = await client.get(
+            "/api/policies?search=PCI", headers=auth(admin_token)
+        )
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["items"][0]["name"] == "PCI Policy"
+
+
+class TestCreatePolicy:
+    @pytest.mark.asyncio
+    async def test_create_basic(self, client, admin_token):
+        """Create a basic policy with no rules."""
+        data = await _create_policy(client, admin_token, name="My Policy")
+        assert data["name"] == "My Policy"
+        assert data["status"] == "draft"
+        assert data["severity"] == "medium"
+        assert data["is_template"] is False
+
+    @pytest.mark.asyncio
+    async def test_create_with_rules_and_conditions(self, client, admin_token):
+        """Create policy with nested detection rules and conditions."""
+        data = await _create_policy(
+            client, admin_token,
+            name="Complex Policy",
+            detection_rules=[
+                {
+                    "name": "SSN Detection",
+                    "rule_type": "detection",
+                    "conditions": [
+                        {
+                            "condition_type": "data_identifier",
+                            "component": "body",
+                            "config": {"identifier_name": "ssn"},
+                            "match_count_min": 3,
+                        }
+                    ],
+                },
+                {
+                    "name": "Keyword Match",
+                    "rule_type": "detection",
+                    "conditions": [
+                        {
+                            "condition_type": "keyword",
+                            "component": "subject",
+                            "config": {"dictionary": "confidential_terms"},
+                        }
+                    ],
+                },
+            ],
+        )
+        assert len(data["detection_rules"]) == 2
+        assert data["detection_rules"][0]["name"] == "SSN Detection"
+        assert len(data["detection_rules"][0]["conditions"]) == 1
+        assert data["detection_rules"][0]["conditions"][0]["match_count_min"] == 3
+
+    @pytest.mark.asyncio
+    async def test_create_with_exceptions(self, client, admin_token):
+        """Create policy with exceptions."""
+        data = await _create_policy(
+            client, admin_token,
+            name="Policy with Exception",
+            exceptions=[
+                {
+                    "name": "Internal Senders",
+                    "scope": "entire_message",
+                    "exception_type": "group",
+                    "conditions": [
+                        {
+                            "condition_type": "identity",
+                            "config": {"field": "sender_email", "operator": "ends_with", "value": "@company.com"},
+                        }
+                    ],
+                }
+            ],
+        )
+        assert len(data["exceptions"]) == 1
+        assert data["exceptions"][0]["name"] == "Internal Senders"
+        assert data["exceptions"][0]["scope"] == "entire_message"
+
+    @pytest.mark.asyncio
+    async def test_create_with_severity_thresholds(self, client, admin_token):
+        """Create policy with severity thresholds."""
+        data = await _create_policy(
+            client, admin_token,
+            name="Threshold Policy",
+            severity_thresholds=[
+                {"threshold": 3, "severity": "medium"},
+                {"threshold": 10, "severity": "high"},
+            ],
+        )
+        assert data["severity_thresholds"] is not None
+        assert len(data["severity_thresholds"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_create_requires_write_permission(self, client, analyst_token):
+        """Analyst (policies:read only) cannot create policies."""
+        resp = await client.post(
+            "/api/policies",
+            json={"name": "Blocked", "severity": "low", "ttd_fallback": "log"},
+            headers=auth(analyst_token),
+        )
+        assert resp.status_code == 403
+
+
+class TestGetPolicy:
+    @pytest.mark.asyncio
+    async def test_get_existing(self, client, admin_token):
+        """Get a policy by ID."""
+        created = await _create_policy(client, admin_token)
+        pid = created["id"]
+
+        resp = await client.get(f"/api/policies/{pid}", headers=auth(admin_token))
+        assert resp.status_code == 200
+        assert resp.json()["id"] == pid
+
+    @pytest.mark.asyncio
+    async def test_get_not_found(self, client, admin_token):
+        """Get non-existent policy returns 404."""
+        fake_id = str(uuid.uuid4())
+        resp = await client.get(f"/api/policies/{fake_id}", headers=auth(admin_token))
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_analyst_can_read(self, client, admin_token, analyst_token):
+        """Analyst with policies:read can view policies."""
+        created = await _create_policy(client, admin_token)
+        pid = created["id"]
+
+        resp = await client.get(f"/api/policies/{pid}", headers=auth(analyst_token))
+        assert resp.status_code == 200
+
+
+class TestUpdatePolicy:
+    @pytest.mark.asyncio
+    async def test_update_name(self, client, admin_token):
+        """Update policy name."""
+        created = await _create_policy(client, admin_token, name="Original")
+        pid = created["id"]
+
+        resp = await client.put(
+            f"/api/policies/{pid}",
+            json={"name": "Updated"},
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Updated"
+
+    @pytest.mark.asyncio
+    async def test_update_severity(self, client, admin_token):
+        """Update policy severity."""
+        created = await _create_policy(client, admin_token, severity="low")
+        pid = created["id"]
+
+        resp = await client.put(
+            f"/api/policies/{pid}",
+            json={"severity": "critical"},
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["severity"] == "critical"
+
+    @pytest.mark.asyncio
+    async def test_update_not_found(self, client, admin_token):
+        """Update non-existent policy returns 404."""
+        fake_id = str(uuid.uuid4())
+        resp = await client.put(
+            f"/api/policies/{fake_id}",
+            json={"name": "Nope"},
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_update_requires_write(self, client, admin_token, analyst_token):
+        """Analyst cannot update policies."""
+        created = await _create_policy(client, admin_token)
+        pid = created["id"]
+
+        resp = await client.put(
+            f"/api/policies/{pid}",
+            json={"name": "Blocked"},
+            headers=auth(analyst_token),
+        )
+        assert resp.status_code == 403
+
+
+class TestDeletePolicy:
+    @pytest.mark.asyncio
+    async def test_delete(self, client, admin_token):
+        """Delete a policy."""
+        created = await _create_policy(client, admin_token)
+        pid = created["id"]
+
+        resp = await client.delete(f"/api/policies/{pid}", headers=auth(admin_token))
+        assert resp.status_code == 204
+
+        # Verify it's gone
+        resp = await client.get(f"/api/policies/{pid}", headers=auth(admin_token))
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_not_found(self, client, admin_token):
+        """Delete non-existent policy returns 404."""
+        fake_id = str(uuid.uuid4())
+        resp = await client.delete(f"/api/policies/{fake_id}", headers=auth(admin_token))
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_requires_write(self, client, admin_token, analyst_token):
+        """Analyst cannot delete policies."""
+        created = await _create_policy(client, admin_token)
+        pid = created["id"]
+
+        resp = await client.delete(f"/api/policies/{pid}", headers=auth(analyst_token))
+        assert resp.status_code == 403
+
+
+class TestActivateSuspend:
+    @pytest.mark.asyncio
+    async def test_activate(self, client, admin_token):
+        """Activate toggles status to active."""
+        created = await _create_policy(client, admin_token)
+        pid = created["id"]
+        assert created["status"] == "draft"
+
+        resp = await client.post(f"/api/policies/{pid}/activate", headers=auth(admin_token))
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "active"
+
+    @pytest.mark.asyncio
+    async def test_suspend(self, client, admin_token):
+        """Suspend toggles status to suspended."""
+        created = await _create_policy(client, admin_token)
+        pid = created["id"]
+
+        # Activate first
+        await client.post(f"/api/policies/{pid}/activate", headers=auth(admin_token))
+
+        resp = await client.post(f"/api/policies/{pid}/suspend", headers=auth(admin_token))
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "suspended"
+
+    @pytest.mark.asyncio
+    async def test_activate_not_found(self, client, admin_token):
+        """Activate non-existent policy returns 404."""
+        fake_id = str(uuid.uuid4())
+        resp = await client.post(f"/api/policies/{fake_id}/activate", headers=auth(admin_token))
+        assert resp.status_code == 404
+
+
+class TestTemplates:
+    @pytest.mark.asyncio
+    async def test_list_templates(self, client, admin_token):
+        """List templates returns seeded templates."""
+        resp = await client.get("/api/policies/templates", headers=auth(admin_token))
+        assert resp.status_code == 200
+        templates = resp.json()
+        assert len(templates) >= 1
+        assert any(t["template_name"] == "pci_dss" for t in templates)
+
+    @pytest.mark.asyncio
+    async def test_create_from_template(self, client, admin_token):
+        """Create from PCI template clones rules and conditions."""
+        resp = await client.post(
+            "/api/policies/from-template",
+            json={
+                "template_name": "pci_dss",
+                "name": "My PCI Policy",
+                "description": "Custom PCI policy",
+            },
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == "My PCI Policy"
+        assert data["status"] == "draft"
+        assert data["is_template"] is False
+        assert len(data["detection_rules"]) >= 1
+        assert data["detection_rules"][0]["name"] == "Credit Card Detection"
+        assert len(data["detection_rules"][0]["conditions"]) >= 1
+
+    @pytest.mark.asyncio
+    async def test_create_from_nonexistent_template(self, client, admin_token):
+        """Create from non-existent template returns 404."""
+        resp = await client.post(
+            "/api/policies/from-template",
+            json={"template_name": "nonexistent", "name": "Fail"},
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_template_not_in_list(self, client, admin_token):
+        """Templates don't appear in the regular policy list."""
+        resp = await client.get("/api/policies", headers=auth(admin_token))
+        data = resp.json()
+        for item in data["items"]:
+            assert item["is_template"] is False
+
+
+class TestRuleManagement:
+    @pytest.mark.asyncio
+    async def test_add_rule(self, client, admin_token):
+        """Add a detection rule to an existing policy."""
+        created = await _create_policy(client, admin_token)
+        pid = created["id"]
+
+        resp = await client.post(
+            f"/api/policies/{pid}/rules",
+            json={
+                "name": "New Rule",
+                "rule_type": "detection",
+                "conditions": [
+                    {
+                        "condition_type": "keyword",
+                        "component": "body",
+                        "config": {"dictionary": "sensitive_words"},
+                    }
+                ],
+            },
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 201
+        rule = resp.json()
+        assert rule["name"] == "New Rule"
+        assert len(rule["conditions"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_remove_rule(self, client, admin_token):
+        """Remove a detection rule from a policy."""
+        created = await _create_policy(
+            client, admin_token,
+            detection_rules=[{"name": "Removable", "rule_type": "detection"}],
+        )
+        pid = created["id"]
+        rule_id = created["detection_rules"][0]["id"]
+
+        resp = await client.delete(
+            f"/api/policies/{pid}/rules/{rule_id}",
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 204
+
+        # Verify rule is gone
+        resp = await client.get(f"/api/policies/{pid}", headers=auth(admin_token))
+        assert len(resp.json()["detection_rules"]) == 0
+
+    @pytest.mark.asyncio
+    async def test_remove_nonexistent_rule(self, client, admin_token):
+        """Remove non-existent rule returns 404."""
+        created = await _create_policy(client, admin_token)
+        pid = created["id"]
+        fake_id = str(uuid.uuid4())
+
+        resp = await client.delete(
+            f"/api/policies/{pid}/rules/{fake_id}",
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 404
+
+
+class TestExceptionManagement:
+    @pytest.mark.asyncio
+    async def test_add_exception(self, client, admin_token):
+        """Add an exception to an existing policy."""
+        created = await _create_policy(client, admin_token)
+        pid = created["id"]
+
+        resp = await client.post(
+            f"/api/policies/{pid}/exceptions",
+            json={
+                "name": "CEO Exception",
+                "scope": "entire_message",
+                "exception_type": "group",
+                "conditions": [
+                    {
+                        "condition_type": "identity",
+                        "config": {"field": "sender_email", "operator": "equals", "value": "ceo@company.com"},
+                    }
+                ],
+            },
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 201
+        exc = resp.json()
+        assert exc["name"] == "CEO Exception"
+        assert len(exc["conditions"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_remove_exception(self, client, admin_token):
+        """Remove an exception from a policy."""
+        created = await _create_policy(
+            client, admin_token,
+            exceptions=[{
+                "name": "Removable",
+                "scope": "entire_message",
+                "exception_type": "detection",
+            }],
+        )
+        pid = created["id"]
+        exc_id = created["exceptions"][0]["id"]
+
+        resp = await client.delete(
+            f"/api/policies/{pid}/exceptions/{exc_id}",
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 204
+
+        # Verify exception is gone
+        resp = await client.get(f"/api/policies/{pid}", headers=auth(admin_token))
+        assert len(resp.json()["exceptions"]) == 0
+
+
+class TestAuditLogging:
+    @pytest.mark.asyncio
+    async def test_create_audit_entry(self, client, admin_token):
+        """Creating a policy produces an audit log entry."""
+        await _create_policy(client, admin_token, name="Audited Policy")
+
+        # Query audit log directly
+        async with TestSessionLocal() as db:
+            from sqlalchemy import select
+
+            result = await db.execute(
+                select(AuditLog).where(AuditLog.action == "policy.create")
+            )
+            entries = result.scalars().all()
+            assert len(entries) >= 1
+            entry = entries[-1]
+            assert entry.resource_type == "policy"
+            assert entry.detail is not None
+            assert "Audited Policy" in entry.detail
+
+    @pytest.mark.asyncio
+    async def test_update_audit_entry(self, client, admin_token):
+        """Updating a policy produces an audit log entry with old/new values."""
+        created = await _create_policy(client, admin_token, name="Before")
+        pid = created["id"]
+
+        await client.put(
+            f"/api/policies/{pid}",
+            json={"name": "After"},
+            headers=auth(admin_token),
+        )
+
+        async with TestSessionLocal() as db:
+            from sqlalchemy import select
+
+            result = await db.execute(
+                select(AuditLog).where(AuditLog.action == "policy.update")
+            )
+            entries = result.scalars().all()
+            assert len(entries) >= 1
+            entry = entries[-1]
+            assert entry.resource_type == "policy"
+            # Changes should contain old/new
+            changes = json.loads(entry.changes) if isinstance(entry.changes, str) else entry.changes
+            assert "old" in changes
+            assert "new" in changes
+
+    @pytest.mark.asyncio
+    async def test_delete_audit_entry(self, client, admin_token):
+        """Deleting a policy produces an audit log entry."""
+        created = await _create_policy(client, admin_token, name="Doomed")
+        pid = created["id"]
+
+        await client.delete(f"/api/policies/{pid}", headers=auth(admin_token))
+
+        async with TestSessionLocal() as db:
+            from sqlalchemy import select
+
+            result = await db.execute(
+                select(AuditLog).where(AuditLog.action == "policy.delete")
+            )
+            entries = result.scalars().all()
+            assert len(entries) >= 1
+            assert "Doomed" in entries[-1].detail
+
+    @pytest.mark.asyncio
+    async def test_activate_audit_entry(self, client, admin_token):
+        """Activating a policy produces an audit log entry."""
+        created = await _create_policy(client, admin_token)
+        pid = created["id"]
+
+        await client.post(f"/api/policies/{pid}/activate", headers=auth(admin_token))
+
+        async with TestSessionLocal() as db:
+            from sqlalchemy import select
+
+            result = await db.execute(
+                select(AuditLog).where(AuditLog.action == "policy.activate")
+            )
+            entries = result.scalars().all()
+            assert len(entries) >= 1
+
+    @pytest.mark.asyncio
+    async def test_add_rule_audit_entry(self, client, admin_token):
+        """Adding a rule produces an audit log entry."""
+        created = await _create_policy(client, admin_token)
+        pid = created["id"]
+
+        await client.post(
+            f"/api/policies/{pid}/rules",
+            json={"name": "Audit Rule", "rule_type": "detection"},
+            headers=auth(admin_token),
+        )
+
+        async with TestSessionLocal() as db:
+            from sqlalchemy import select
+
+            result = await db.execute(
+                select(AuditLog).where(AuditLog.action == "policy.add_rule")
+            )
+            entries = result.scalars().all()
+            assert len(entries) >= 1
+
+
+class TestAuth:
+    @pytest.mark.asyncio
+    async def test_no_token_401(self, client):
+        """No auth token returns 401."""
+        resp = await client.get("/api/policies")
+        assert resp.status_code in (401, 403)
+
+    @pytest.mark.asyncio
+    async def test_analyst_read_200(self, client, admin_token, analyst_token):
+        """Analyst can read policies."""
+        await _create_policy(client, admin_token)
+        resp = await client.get("/api/policies", headers=auth(analyst_token))
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_analyst_write_403(self, client, analyst_token):
+        """Analyst cannot create policies."""
+        resp = await client.post(
+            "/api/policies",
+            json={"name": "Blocked", "severity": "low", "ttd_fallback": "log"},
+            headers=auth(analyst_token),
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_analyst_cannot_activate(self, client, admin_token, analyst_token):
+        """Analyst cannot activate policies."""
+        created = await _create_policy(client, admin_token)
+        pid = created["id"]
+
+        resp = await client.post(
+            f"/api/policies/{pid}/activate",
+            headers=auth(analyst_token),
+        )
+        assert resp.status_code == 403
+
+
+class TestCompoundScenario:
+    """End-to-end compound scenario matching acceptance criteria."""
+
+    @pytest.mark.asyncio
+    async def test_full_lifecycle(self, client, admin_token):
+        """Create from template → add custom rule → activate → verify → suspend → delete."""
+        # 1. Create from PCI template
+        resp = await client.post(
+            "/api/policies/from-template",
+            json={
+                "template_name": "pci_dss",
+                "name": "Production PCI",
+            },
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 201
+        policy = resp.json()
+        pid = policy["id"]
+        assert policy["status"] == "draft"
+        assert len(policy["detection_rules"]) >= 1
+
+        # 2. Add custom keyword rule
+        resp = await client.post(
+            f"/api/policies/{pid}/rules",
+            json={
+                "name": "Confidential Keywords",
+                "rule_type": "detection",
+                "conditions": [
+                    {
+                        "condition_type": "keyword",
+                        "component": "body",
+                        "config": {"dictionary": "confidential"},
+                    }
+                ],
+            },
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 201
+
+        # 3. Add exception for internal sender
+        resp = await client.post(
+            f"/api/policies/{pid}/exceptions",
+            json={
+                "name": "Internal Senders",
+                "scope": "entire_message",
+                "exception_type": "group",
+                "conditions": [
+                    {
+                        "condition_type": "identity",
+                        "config": {"field": "sender_email", "operator": "ends_with", "value": "@company.com"},
+                    }
+                ],
+            },
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 201
+
+        # 4. Activate
+        resp = await client.post(f"/api/policies/{pid}/activate", headers=auth(admin_token))
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "active"
+
+        # 5. Verify full policy
+        resp = await client.get(f"/api/policies/{pid}", headers=auth(admin_token))
+        assert resp.status_code == 200
+        policy = resp.json()
+        assert len(policy["detection_rules"]) == 2
+        assert len(policy["exceptions"]) == 1
+
+        # 6. Suspend
+        resp = await client.post(f"/api/policies/{pid}/suspend", headers=auth(admin_token))
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "suspended"
+
+        # 7. Delete
+        resp = await client.delete(f"/api/policies/{pid}", headers=auth(admin_token))
+        assert resp.status_code == 204
+
+        # 8. Verify audit trail
+        async with TestSessionLocal() as db:
+            from sqlalchemy import select
+
+            result = await db.execute(
+                select(AuditLog).where(
+                    AuditLog.resource_id == pid
+                ).order_by(AuditLog.created_at)
+            )
+            entries = result.scalars().all()
+            actions = [e.action for e in entries]
+            assert "policy.create_from_template" in actions
+            assert "policy.add_rule" in actions
+            assert "policy.add_exception" in actions
+            assert "policy.activate" in actions
+            assert "policy.suspend" in actions
+            assert "policy.delete" in actions


### PR DESCRIPTION
## Summary
- **Policy service** (`policy_service.py`): Full CRUD with eager-loaded relationships, pagination, status/search filtering, template cloning with deep-copy of rules/conditions/exceptions
- **Policy API router** (`policies.py`): 14 endpoints — list, create, get, update, delete, activate, suspend, add/remove rules, add/remove exceptions, list templates, create from template
- **Audit logging**: Every mutation (create, update, delete, activate, suspend, add/remove rule, add/remove exception) produces an `AuditLog` entry with actor, action, changes, and client IP
- **RBAC enforcement**: Admin has `policies:read` + `policies:write`, Analyst has `policies:read` only

## Acceptance Criteria
- ✅ Create from PCI template → policy with pre-configured rules
- ✅ Add custom rule to existing policy
- ✅ Activate toggles status
- ✅ Audit log entry per mutation (6 action types verified)
- ✅ Analyst can read but cannot create/update/delete (403)

## Test plan
- [x] 42 new tests in `test_policies.py`
- [x] Full suite: 445 tests passing
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)