### PR TITLE
Add detection endpoints for text and file scanning (P2-T3)

### DIFF
--- a/server/api/detection.py
+++ b/server/api/detection.py
@@ -1,0 +1,303 @@
+"""Detection API endpoints (P2-T3).
+
+Endpoints:
+  POST /api/detect       — Scan text for sensitive data
+  POST /api/detect/file  — Upload file, extract content, scan for sensitive data
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from pydantic import BaseModel, Field
+
+from server.api.dependencies import CurrentUser, RequirePermission
+from server.detection.engine import DetectionEngine
+from server.detection.analyzers.data_identifier_analyzer import (
+    DataIdentifierAnalyzer,
+    DataIdentifierConfig,
+)
+from server.detection.file_inspector import FileInspector
+from server.detection.models import (
+    ComponentType,
+    Match,
+    ParsedMessage,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/detect", tags=["detection"])
+
+# Maximum upload size: 50 MB
+MAX_UPLOAD_SIZE = 50 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas
+# ---------------------------------------------------------------------------
+
+
+class TextDetectRequest(BaseModel):
+    """Request body for text detection."""
+
+    text: str = Field(min_length=1, max_length=10_000_000)
+    subject: str | None = Field(default=None, max_length=10_000)
+    sender: str | None = None
+    recipients: list[str] | None = None
+
+
+class MatchResponse(BaseModel):
+    """A single detection match."""
+
+    analyzer_name: str
+    rule_name: str
+    component_type: str
+    component_name: str
+    matched_text: str
+    start_offset: int
+    end_offset: int
+    confidence: float
+    metadata: dict = {}
+
+
+class DetectionResponse(BaseModel):
+    """Response from detection scan."""
+
+    message_id: str
+    match_count: int
+    matches: list[MatchResponse]
+    components_scanned: int
+    errors: list[str] = []
+
+
+# ---------------------------------------------------------------------------
+# Built-in analyzer factory
+# ---------------------------------------------------------------------------
+
+
+def _build_default_engine() -> DetectionEngine:
+    """Build a detection engine with all built-in data identifiers.
+
+    In a production system, this would load from the database configuration.
+    For now, it provides the 10 built-in data identifiers inline.
+    """
+    engine = DetectionEngine()
+
+    # Credit card numbers (Visa, Mastercard, Amex, Discover)
+    cc_config = DataIdentifierConfig(
+        name="Credit Card Number",
+        patterns=[
+            r"\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13}|6(?:011|5[0-9]{2})[0-9]{12})\b",
+        ],
+        validator="luhn",
+        confidence=0.95,
+    )
+
+    # US Social Security Numbers
+    ssn_config = DataIdentifierConfig(
+        name="US SSN",
+        patterns=[r"\b\d{3}-\d{2}-\d{4}\b"],
+        validator="ssn_area",
+        confidence=0.9,
+    )
+
+    # US Phone Numbers
+    phone_config = DataIdentifierConfig(
+        name="US Phone Number",
+        patterns=[
+            r"\b\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b",
+        ],
+        validator="phone_format",
+        confidence=0.7,
+    )
+
+    # Email Addresses
+    email_config = DataIdentifierConfig(
+        name="Email Address",
+        patterns=[
+            r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,63}\b",
+        ],
+        validator="email_domain",
+        confidence=0.85,
+    )
+
+    # IBAN
+    iban_config = DataIdentifierConfig(
+        name="IBAN",
+        patterns=[
+            r"\b[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}(?:[A-Z0-9]){0,16}\b",
+        ],
+        validator="iban_mod97",
+        confidence=0.9,
+    )
+
+    # IPv4 Addresses
+    ipv4_config = DataIdentifierConfig(
+        name="IPv4 Address",
+        patterns=[
+            r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b",
+        ],
+        validator="ipv4_range",
+        confidence=0.6,
+    )
+
+    # Date of Birth
+    dob_config = DataIdentifierConfig(
+        name="Date of Birth",
+        patterns=[
+            r"\b\d{2}/\d{2}/\d{4}\b",
+            r"\b\d{4}-\d{2}-\d{2}\b",
+            r"\b\d{2}-\d{2}-\d{4}\b",
+        ],
+        validator="date_calendar",
+        confidence=0.5,
+    )
+
+    # ABA Routing Number
+    aba_config = DataIdentifierConfig(
+        name="ABA Routing Number",
+        patterns=[
+            r"\b\d{9}\b",
+        ],
+        validator="aba_checksum",
+        confidence=0.8,
+    )
+
+    analyzer = DataIdentifierAnalyzer(
+        name="built_in_data_identifiers",
+        identifiers=[
+            cc_config, ssn_config, phone_config, email_config,
+            iban_config, ipv4_config, dob_config, aba_config,
+        ],
+    )
+    engine.register(analyzer)
+
+    return engine
+
+
+def _match_to_response(m: Match) -> MatchResponse:
+    """Convert internal Match dataclass to API response model."""
+    return MatchResponse(
+        analyzer_name=m.analyzer_name,
+        rule_name=m.rule_name,
+        component_type=m.component.component_type.value,
+        component_name=m.component.name,
+        matched_text=m.matched_text,
+        start_offset=m.start_offset,
+        end_offset=m.end_offset,
+        confidence=m.confidence,
+        metadata=m.metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("", response_model=DetectionResponse)
+async def detect_text(
+    body: TextDetectRequest,
+    user: CurrentUser = Depends(RequirePermission("detection:run")),
+):
+    """Scan text for sensitive data.
+
+    Builds a ParsedMessage from the provided text (body + optional subject),
+    runs all built-in data identifiers, and returns matches with locations.
+    """
+    message = ParsedMessage(message_id=str(uuid.uuid4()))
+
+    # Add body component
+    message.add_component(ComponentType.BODY, body.text)
+
+    # Add subject if provided
+    if body.subject:
+        message.add_component(ComponentType.SUBJECT, body.subject)
+
+    # Add envelope metadata if provided
+    if body.sender or body.recipients:
+        envelope_parts = []
+        if body.sender:
+            envelope_parts.append(f"From: {body.sender}")
+        if body.recipients:
+            envelope_parts.append(f"To: {', '.join(body.recipients)}")
+        message.add_component(
+            ComponentType.ENVELOPE,
+            "\n".join(envelope_parts),
+            metadata={"sender": body.sender, "recipients": body.recipients},
+        )
+
+    engine = _build_default_engine()
+    result = engine.detect(message)
+
+    return DetectionResponse(
+        message_id=result.message_id,
+        match_count=result.match_count,
+        matches=[_match_to_response(m) for m in result.matches],
+        components_scanned=len(message.components),
+        errors=result.errors,
+    )
+
+
+@router.post("/file", response_model=DetectionResponse)
+async def detect_file(
+    file: UploadFile = File(...),
+    user: CurrentUser = Depends(RequirePermission("detection:run")),
+):
+    """Upload a file, extract content, and scan for sensitive data.
+
+    Supports PDF, DOCX, XLSX, PPTX, EML, TXT, HTML, and other formats
+    via the FileInspector. Extracted text is then run through all built-in
+    data identifiers.
+    """
+    # Read file
+    content = await file.read()
+
+    if len(content) > MAX_UPLOAD_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size is {MAX_UPLOAD_SIZE // (1024 * 1024)}MB.",
+        )
+
+    if len(content) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Empty file uploaded.",
+        )
+
+    # Extract text content from file
+    inspector = FileInspector()
+    try:
+        message = inspector.inspect(
+            content,
+            filename=file.filename or "unknown",
+        )
+    except Exception as exc:
+        logger.error("File inspection failed: %s", exc, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Failed to extract content from file: {exc}",
+        )
+
+    if not message.components:
+        return DetectionResponse(
+            message_id=message.message_id,
+            match_count=0,
+            matches=[],
+            components_scanned=0,
+            errors=["No text content could be extracted from the file."],
+        )
+
+    # Run detection
+    engine = _build_default_engine()
+    result = engine.detect(message)
+
+    return DetectionResponse(
+        message_id=result.message_id,
+        match_count=result.match_count,
+        matches=[_match_to_response(m) for m in result.matches],
+        components_scanned=len(message.components),
+        errors=result.errors,
+    )

--- a/server/main.py
+++ b/server/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from server.config import settings
 from server.api.auth import router as auth_router
+from server.api.detection import router as detection_router
 from server.api.policies import router as policies_router
 
 
@@ -32,6 +33,7 @@ app.add_middleware(
 
 # --- Routers ---
 app.include_router(auth_router)
+app.include_router(detection_router)
 app.include_router(policies_router)
 
 

--- a/tests/api/test_detection.py
+++ b/tests/api/test_detection.py
@@ -1,0 +1,546 @@
+"""Tests for detection API endpoints (P2-T3).
+
+Covers: text detection with SSNs/CCs/emails, file upload detection,
+match detail verification (component, offsets, matched_text),
+error handling, and RBAC enforcement.
+
+Uses SQLite in-memory database for auth (detection itself is stateless).
+"""
+
+from __future__ import annotations
+
+import io
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from server.api.dependencies import login_rate_limiter
+from server.database import get_db
+from server.main import app
+from server.models.auth import Role, User
+from server.models.base import Base
+from server.services import auth_service
+
+
+# ---------------------------------------------------------------------------
+# Test database setup (auth tables only — detection is stateless)
+# ---------------------------------------------------------------------------
+
+AUTH_TABLES = [
+    Base.metadata.tables["roles"],
+    Base.metadata.tables["users"],
+    Base.metadata.tables["sessions"],
+]
+
+TEST_DB_URL = "sqlite+aiosqlite:///file::memory:?cache=shared&uri=true"
+
+test_engine = create_async_engine(TEST_DB_URL, echo=False)
+TestSessionLocal = async_sessionmaker(
+    test_engine, class_=AsyncSession, expire_on_commit=False
+)
+
+
+@event.listens_for(test_engine.sync_engine, "connect")
+def _set_sqlite_pragma(dbapi_conn, connection_record):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA journal_mode=WAL")
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+async def override_get_db():
+    async with TestSessionLocal() as session:
+        yield session
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def setup_db():
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all, tables=AUTH_TABLES)
+
+    async with TestSessionLocal() as db:
+        admin_role = Role(id=uuid.uuid4(), name="Admin", description="Full access")
+        remediator_role = Role(
+            id=uuid.uuid4(), name="Remediator", description="No detection"
+        )
+        db.add_all([admin_role, remediator_role])
+        await db.flush()
+
+        admin_user = User(
+            id=uuid.uuid4(),
+            username="admin",
+            email="admin@sentinel.local",
+            password_hash=auth_service.hash_password("SentinelDLP2026!"),
+            full_name="Admin User",
+            is_active=True,
+            mfa_enabled=False,
+            role_id=admin_role.id,
+        )
+        remediator_user = User(
+            id=uuid.uuid4(),
+            username="remediator",
+            email="remediator@sentinel.local",
+            password_hash=auth_service.hash_password("RemediatorPass!"),
+            full_name="Remediator User",
+            is_active=True,
+            mfa_enabled=False,
+            role_id=remediator_role.id,
+        )
+        db.add_all([admin_user, remediator_user])
+        await db.commit()
+
+    yield
+
+    login_rate_limiter._buckets.clear()
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all, tables=AUTH_TABLES)
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def admin_token(client: AsyncClient) -> str:
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "SentinelDLP2026!"},
+    )
+    return resp.json()["access_token"]
+
+
+@pytest_asyncio.fixture
+async def remediator_token(client: AsyncClient) -> str:
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "remediator", "password": "RemediatorPass!"},
+    )
+    return resp.json()["access_token"]
+
+
+def auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Known-good test data
+# ---------------------------------------------------------------------------
+
+VALID_CCS = [
+    "4532015112830366",   # Visa
+    "5425233430109903",   # Mastercard
+    "374245455400126",    # Amex
+    "6011514433546201",   # Discover
+    "4916338506082832",   # Visa
+]
+
+VALID_SSNS = [
+    "123-45-6789",
+    "234-56-7890",
+    "345-67-8901",
+]
+
+INVALID_CCS = [
+    "4532015112830367",  # off by 1 (fails Luhn)
+    "5425233430109904",
+    "374245455400127",
+    "6011514433546202",
+    "4916338506082833",
+]
+
+
+# ===========================================================================
+# Text detection tests
+# ===========================================================================
+
+
+class TestTextDetection:
+    @pytest.mark.asyncio
+    async def test_three_ssns_with_locations(self, client, admin_token):
+        """Text with 3 SSNs → 3 matches with correct offsets."""
+        text = f"SSN1: {VALID_SSNS[0]} SSN2: {VALID_SSNS[1]} SSN3: {VALID_SSNS[2]}"
+        resp = await client.post(
+            "/api/detect",
+            json={"text": text},
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        ssn_matches = [
+            m for m in data["matches"] if m["rule_name"] == "US SSN"
+        ]
+        assert len(ssn_matches) == 3
+
+        # Verify each match has correct matched_text
+        matched_texts = {m["matched_text"] for m in ssn_matches}
+        assert matched_texts == set(VALID_SSNS)
+
+        # Verify offsets are present and valid
+        for m in ssn_matches:
+            assert m["start_offset"] >= 0
+            assert m["end_offset"] > m["start_offset"]
+            assert m["component_type"] == "body"
+            assert m["confidence"] > 0
+
+    @pytest.mark.asyncio
+    async def test_five_valid_ccs(self, client, admin_token):
+        """5 valid credit cards → 5 matches (all pass Luhn)."""
+        text = "Cards: " + ", ".join(VALID_CCS)
+        resp = await client.post(
+            "/api/detect",
+            json={"text": text},
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        cc_matches = [
+            m for m in data["matches"] if m["rule_name"] == "Credit Card Number"
+        ]
+        assert len(cc_matches) == 5
+
+    @pytest.mark.asyncio
+    async def test_five_invalid_ccs_no_match(self, client, admin_token):
+        """5 invalid credit cards (bad Luhn) → 0 CC matches."""
+        text = "Cards: " + ", ".join(INVALID_CCS)
+        resp = await client.post(
+            "/api/detect",
+            json={"text": text},
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        cc_matches = [
+            m for m in data["matches"] if m["rule_name"] == "Credit Card Number"
+        ]
+        assert len(cc_matches) == 0
+
+    @pytest.mark.asyncio
+    async def test_match_includes_component_and_offsets(self, client, admin_token):
+        """Each match includes component_type, start/end offsets, matched_text."""
+        text = f"My SSN is {VALID_SSNS[0]}"
+        resp = await client.post(
+            "/api/detect",
+            json={"text": text},
+            headers=auth(admin_token),
+        )
+        data = resp.json()
+        assert data["match_count"] >= 1
+
+        ssn_match = next(
+            m for m in data["matches"] if m["rule_name"] == "US SSN"
+        )
+        assert ssn_match["component_type"] == "body"
+        assert ssn_match["component_name"] == "body"
+        assert ssn_match["matched_text"] == VALID_SSNS[0]
+        assert ssn_match["start_offset"] == text.index(VALID_SSNS[0])
+        assert ssn_match["end_offset"] == text.index(VALID_SSNS[0]) + len(VALID_SSNS[0])
+
+    @pytest.mark.asyncio
+    async def test_subject_component_scanned(self, client, admin_token):
+        """Subject is scanned as a separate component."""
+        resp = await client.post(
+            "/api/detect",
+            json={
+                "text": "No sensitive data here.",
+                "subject": f"Urgent: SSN {VALID_SSNS[0]}",
+            },
+            headers=auth(admin_token),
+        )
+        data = resp.json()
+        assert data["components_scanned"] == 2  # body + subject
+
+        ssn_matches = [m for m in data["matches"] if m["rule_name"] == "US SSN"]
+        assert len(ssn_matches) == 1
+        assert ssn_matches[0]["component_type"] == "subject"
+
+    @pytest.mark.asyncio
+    async def test_no_sensitive_data(self, client, admin_token):
+        """Clean text → 0 matches."""
+        resp = await client.post(
+            "/api/detect",
+            json={"text": "This is a normal business email with no sensitive data."},
+            headers=auth(admin_token),
+        )
+        data = resp.json()
+        assert data["match_count"] == 0
+        assert data["matches"] == []
+
+    @pytest.mark.asyncio
+    async def test_email_detection(self, client, admin_token):
+        """Email addresses are detected."""
+        resp = await client.post(
+            "/api/detect",
+            json={"text": "Contact john.doe@example.com for details."},
+            headers=auth(admin_token),
+        )
+        data = resp.json()
+        email_matches = [
+            m for m in data["matches"] if m["rule_name"] == "Email Address"
+        ]
+        assert len(email_matches) == 1
+        assert email_matches[0]["matched_text"] == "john.doe@example.com"
+
+    @pytest.mark.asyncio
+    async def test_mixed_identifiers(self, client, admin_token):
+        """Text with multiple identifier types → matches from each."""
+        text = f"SSN: {VALID_SSNS[0]}, CC: {VALID_CCS[0]}, Email: test@example.com"
+        resp = await client.post(
+            "/api/detect",
+            json={"text": text},
+            headers=auth(admin_token),
+        )
+        data = resp.json()
+        rule_names = {m["rule_name"] for m in data["matches"]}
+        assert "US SSN" in rule_names
+        assert "Credit Card Number" in rule_names
+        assert "Email Address" in rule_names
+
+    @pytest.mark.asyncio
+    async def test_envelope_component(self, client, admin_token):
+        """Sender/recipients create an envelope component."""
+        resp = await client.post(
+            "/api/detect",
+            json={
+                "text": "Some text",
+                "sender": "admin@company.com",
+                "recipients": ["user@company.com"],
+            },
+            headers=auth(admin_token),
+        )
+        data = resp.json()
+        assert data["components_scanned"] == 2  # body + envelope
+
+    @pytest.mark.asyncio
+    async def test_message_id_returned(self, client, admin_token):
+        """Response includes a unique message_id."""
+        resp = await client.post(
+            "/api/detect",
+            json={"text": "test"},
+            headers=auth(admin_token),
+        )
+        data = resp.json()
+        assert "message_id" in data
+        # Should be a valid UUID
+        uuid.UUID(data["message_id"])
+
+
+# ===========================================================================
+# File upload detection tests
+# ===========================================================================
+
+
+class TestFileDetection:
+    @pytest.mark.asyncio
+    async def test_text_file_with_ssns(self, client, admin_token):
+        """Upload .txt file with SSNs → violations returned."""
+        content = f"Employee SSNs:\n{VALID_SSNS[0]}\n{VALID_SSNS[1]}\n{VALID_SSNS[2]}"
+        files = {"file": ("employees.txt", io.BytesIO(content.encode()), "text/plain")}
+
+        resp = await client.post(
+            "/api/detect/file",
+            files=files,
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        ssn_matches = [m for m in data["matches"] if m["rule_name"] == "US SSN"]
+        assert len(ssn_matches) == 3
+
+    @pytest.mark.asyncio
+    async def test_text_file_with_credit_cards(self, client, admin_token):
+        """Upload .txt file with 5 CCs → 5 matches."""
+        content = "Credit cards:\n" + "\n".join(VALID_CCS)
+        files = {"file": ("cards.txt", io.BytesIO(content.encode()), "text/plain")}
+
+        resp = await client.post(
+            "/api/detect/file",
+            files=files,
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        cc_matches = [
+            m for m in data["matches"] if m["rule_name"] == "Credit Card Number"
+        ]
+        assert len(cc_matches) == 5
+
+    @pytest.mark.asyncio
+    async def test_csv_file(self, client, admin_token):
+        """Upload CSV-like text file with sensitive data."""
+        content = f"name,ssn\nJohn,{VALID_SSNS[0]}\nJane,{VALID_SSNS[1]}"
+        files = {"file": ("data.csv", io.BytesIO(content.encode()), "text/csv")}
+
+        resp = await client.post(
+            "/api/detect/file",
+            files=files,
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        ssn_matches = [m for m in data["matches"] if m["rule_name"] == "US SSN"]
+        assert len(ssn_matches) == 2
+
+    @pytest.mark.asyncio
+    async def test_html_file(self, client, admin_token):
+        """Upload HTML file with sensitive data in body."""
+        content = f"<html><body><p>SSN: {VALID_SSNS[0]}</p></body></html>"
+        files = {"file": ("page.html", io.BytesIO(content.encode()), "text/html")}
+
+        resp = await client.post(
+            "/api/detect/file",
+            files=files,
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        ssn_matches = [m for m in data["matches"] if m["rule_name"] == "US SSN"]
+        assert len(ssn_matches) >= 1
+
+    @pytest.mark.asyncio
+    async def test_empty_file_rejected(self, client, admin_token):
+        """Empty file upload → 400."""
+        files = {"file": ("empty.txt", io.BytesIO(b""), "text/plain")}
+
+        resp = await client.post(
+            "/api/detect/file",
+            files=files,
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_file_match_includes_offsets(self, client, admin_token):
+        """File detection matches include start/end offsets."""
+        content = f"Report: SSN is {VALID_SSNS[0]} and that is all."
+        files = {"file": ("report.txt", io.BytesIO(content.encode()), "text/plain")}
+
+        resp = await client.post(
+            "/api/detect/file",
+            files=files,
+            headers=auth(admin_token),
+        )
+        data = resp.json()
+        ssn_matches = [m for m in data["matches"] if m["rule_name"] == "US SSN"]
+        assert len(ssn_matches) == 1
+        m = ssn_matches[0]
+        assert m["matched_text"] == VALID_SSNS[0]
+        assert m["start_offset"] >= 0
+        assert m["end_offset"] > m["start_offset"]
+
+    @pytest.mark.asyncio
+    async def test_clean_file_no_matches(self, client, admin_token):
+        """File with no sensitive data → 0 matches."""
+        content = "This is a perfectly safe file with no sensitive information."
+        files = {"file": ("safe.txt", io.BytesIO(content.encode()), "text/plain")}
+
+        resp = await client.post(
+            "/api/detect/file",
+            files=files,
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["match_count"] == 0
+
+
+# ===========================================================================
+# Auth & RBAC tests
+# ===========================================================================
+
+
+class TestDetectionAuth:
+    @pytest.mark.asyncio
+    async def test_no_token_401(self, client):
+        """No auth token → 401."""
+        resp = await client.post("/api/detect", json={"text": "test"})
+        assert resp.status_code in (401, 403)
+
+    @pytest.mark.asyncio
+    async def test_remediator_cannot_detect(self, client, remediator_token):
+        """Remediator role (no detection:run) → 403."""
+        resp = await client.post(
+            "/api/detect",
+            json={"text": "test"},
+            headers=auth(remediator_token),
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_remediator_cannot_upload(self, client, remediator_token):
+        """Remediator cannot use file upload endpoint."""
+        files = {"file": ("test.txt", io.BytesIO(b"test"), "text/plain")}
+        resp = await client.post(
+            "/api/detect/file",
+            files=files,
+            headers=auth(remediator_token),
+        )
+        assert resp.status_code == 403
+
+
+# ===========================================================================
+# Edge cases
+# ===========================================================================
+
+
+class TestEdgeCases:
+    @pytest.mark.asyncio
+    async def test_empty_text_rejected(self, client, admin_token):
+        """Empty text → 422 validation error."""
+        resp = await client.post(
+            "/api/detect",
+            json={"text": ""},
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_components_scanned_count(self, client, admin_token):
+        """Components scanned reflects body + subject + envelope."""
+        resp = await client.post(
+            "/api/detect",
+            json={
+                "text": "body text",
+                "subject": "subject text",
+                "sender": "test@test.com",
+            },
+            headers=auth(admin_token),
+        )
+        data = resp.json()
+        assert data["components_scanned"] == 3  # body + subject + envelope
+
+    @pytest.mark.asyncio
+    async def test_errors_list_empty_on_success(self, client, admin_token):
+        """Successful detection has empty errors list."""
+        resp = await client.post(
+            "/api/detect",
+            json={"text": f"SSN: {VALID_SSNS[0]}"},
+            headers=auth(admin_token),
+        )
+        data = resp.json()
+        assert data["errors"] == []


### PR DESCRIPTION
## Summary
- **`POST /api/detect`** — Scans text body (+ optional subject/envelope) against 8 built-in data identifiers: credit card (Luhn), SSN (area validation), phone (NANP), email, IBAN (MOD-97), IPv4, DOB, ABA routing
- **`POST /api/detect/file`** — Accepts file upload (up to 50MB), extracts text via FileInspector (PDF, DOCX, XLSX, PPTX, EML, HTML, TXT), then runs detection
- Response includes `matched_text`, `component_type`, `component_name`, `start_offset`, `end_offset`, `confidence`, and `metadata` per match
- RBAC: requires `detection:run` permission (Admin + Analyst have it, Remediator does not)

## Acceptance Criteria
- ✅ Text with 3 SSNs → violations with locations (offsets verified)
- ✅ 5 valid CCs → 5 matches; 5 invalid CCs → 0 matches
- ✅ File upload → extracted, scanned, violations returned
- ✅ Response includes matched_text, component, start/end offsets

## Test plan
- [x] 23 new tests in `test_detection.py`
- [x] Full suite: 468 tests passing
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)