### PR TITLE
Add supporting endpoints: identifiers, dictionaries, rules, users, audit, search (P2-T5)

### DIFF
--- a/server/api/dictionaries.py
+++ b/server/api/dictionaries.py
@@ -1,0 +1,124 @@
+"""Keyword Dictionary CRUD endpoints (P2-T5).
+
+Endpoints:
+  GET    /api/dictionaries       — List keyword dictionaries
+  POST   /api/dictionaries       — Create dictionary
+  GET    /api/dictionaries/{id}  — Get dictionary
+  PUT    /api/dictionaries/{id}  — Update dictionary
+  DELETE /api/dictionaries/{id}  — Delete dictionary
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.api.dependencies import RequirePermission
+from server.database import get_db
+from server.models.detection import KeywordDictionary
+from server.schemas.detection import KeywordDictionaryCreate, KeywordDictionaryResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/dictionaries", tags=["keyword-dictionaries"])
+
+
+@router.get("", response_model=list[KeywordDictionaryResponse])
+async def list_dictionaries(
+    user=Depends(RequirePermission("policies:read")),
+    db: AsyncSession = Depends(get_db),
+    active_only: bool = Query(default=False),
+):
+    """List all keyword dictionaries."""
+    stmt = select(KeywordDictionary).order_by(KeywordDictionary.name)
+    if active_only:
+        stmt = stmt.where(KeywordDictionary.is_active == True)  # noqa: E712
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+@router.post("", response_model=KeywordDictionaryResponse, status_code=status.HTTP_201_CREATED)
+async def create_dictionary(
+    body: KeywordDictionaryCreate,
+    user=Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a keyword dictionary."""
+    existing = await db.execute(
+        select(KeywordDictionary).where(KeywordDictionary.name == body.name)
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(status_code=409, detail=f"Dictionary '{body.name}' already exists")
+
+    dictionary = KeywordDictionary(
+        name=body.name,
+        description=body.description,
+        config=body.config,
+        is_active=body.is_active,
+    )
+    db.add(dictionary)
+    await db.commit()
+    await db.refresh(dictionary)
+    return dictionary
+
+
+@router.get("/{dictionary_id}", response_model=KeywordDictionaryResponse)
+async def get_dictionary(
+    dictionary_id: uuid.UUID,
+    user=Depends(RequirePermission("policies:read")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get a keyword dictionary by ID."""
+    result = await db.execute(
+        select(KeywordDictionary).where(KeywordDictionary.id == dictionary_id)
+    )
+    dictionary = result.scalar_one_or_none()
+    if not dictionary:
+        raise HTTPException(status_code=404, detail="Dictionary not found")
+    return dictionary
+
+
+@router.put("/{dictionary_id}", response_model=KeywordDictionaryResponse)
+async def update_dictionary(
+    dictionary_id: uuid.UUID,
+    body: KeywordDictionaryCreate,
+    user=Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update a keyword dictionary."""
+    result = await db.execute(
+        select(KeywordDictionary).where(KeywordDictionary.id == dictionary_id)
+    )
+    dictionary = result.scalar_one_or_none()
+    if not dictionary:
+        raise HTTPException(status_code=404, detail="Dictionary not found")
+
+    dictionary.name = body.name
+    dictionary.description = body.description
+    dictionary.config = body.config
+    dictionary.is_active = body.is_active
+    await db.commit()
+    await db.refresh(dictionary)
+    return dictionary
+
+
+@router.delete("/{dictionary_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_dictionary(
+    dictionary_id: uuid.UUID,
+    user=Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a keyword dictionary."""
+    result = await db.execute(
+        select(KeywordDictionary).where(KeywordDictionary.id == dictionary_id)
+    )
+    dictionary = result.scalar_one_or_none()
+    if not dictionary:
+        raise HTTPException(status_code=404, detail="Dictionary not found")
+
+    await db.delete(dictionary)
+    await db.commit()

--- a/server/api/identifiers.py
+++ b/server/api/identifiers.py
@@ -1,0 +1,128 @@
+"""Data Identifier CRUD endpoints (P2-T5).
+
+Endpoints:
+  GET    /api/identifiers       — List data identifiers
+  POST   /api/identifiers       — Create custom identifier
+  GET    /api/identifiers/{id}  — Get identifier
+  PUT    /api/identifiers/{id}  — Update identifier
+  DELETE /api/identifiers/{id}  — Delete identifier (custom only)
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.api.dependencies import RequirePermission
+from server.database import get_db
+from server.models.detection import DataIdentifier
+from server.schemas.detection import DataIdentifierCreate, DataIdentifierResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/identifiers", tags=["data-identifiers"])
+
+
+@router.get("", response_model=list[DataIdentifierResponse])
+async def list_identifiers(
+    user=Depends(RequirePermission("policies:read")),
+    db: AsyncSession = Depends(get_db),
+    active_only: bool = Query(default=False),
+):
+    """List all data identifiers."""
+    stmt = select(DataIdentifier).order_by(DataIdentifier.name)
+    if active_only:
+        stmt = stmt.where(DataIdentifier.is_active == True)  # noqa: E712
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+@router.post("", response_model=DataIdentifierResponse, status_code=status.HTTP_201_CREATED)
+async def create_identifier(
+    body: DataIdentifierCreate,
+    user=Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a custom data identifier."""
+    # Check name uniqueness
+    existing = await db.execute(
+        select(DataIdentifier).where(DataIdentifier.name == body.name)
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(status_code=409, detail=f"Identifier '{body.name}' already exists")
+
+    identifier = DataIdentifier(
+        name=body.name,
+        description=body.description,
+        config=body.config,
+        is_builtin=False,
+        is_active=body.is_active,
+    )
+    db.add(identifier)
+    await db.commit()
+    await db.refresh(identifier)
+    return identifier
+
+
+@router.get("/{identifier_id}", response_model=DataIdentifierResponse)
+async def get_identifier(
+    identifier_id: uuid.UUID,
+    user=Depends(RequirePermission("policies:read")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get a data identifier by ID."""
+    result = await db.execute(
+        select(DataIdentifier).where(DataIdentifier.id == identifier_id)
+    )
+    identifier = result.scalar_one_or_none()
+    if not identifier:
+        raise HTTPException(status_code=404, detail="Identifier not found")
+    return identifier
+
+
+@router.put("/{identifier_id}", response_model=DataIdentifierResponse)
+async def update_identifier(
+    identifier_id: uuid.UUID,
+    body: DataIdentifierCreate,
+    user=Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update a data identifier."""
+    result = await db.execute(
+        select(DataIdentifier).where(DataIdentifier.id == identifier_id)
+    )
+    identifier = result.scalar_one_or_none()
+    if not identifier:
+        raise HTTPException(status_code=404, detail="Identifier not found")
+
+    identifier.name = body.name
+    identifier.description = body.description
+    identifier.config = body.config
+    identifier.is_active = body.is_active
+    await db.commit()
+    await db.refresh(identifier)
+    return identifier
+
+
+@router.delete("/{identifier_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_identifier(
+    identifier_id: uuid.UUID,
+    user=Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a custom data identifier (built-in cannot be deleted)."""
+    result = await db.execute(
+        select(DataIdentifier).where(DataIdentifier.id == identifier_id)
+    )
+    identifier = result.scalar_one_or_none()
+    if not identifier:
+        raise HTTPException(status_code=404, detail="Identifier not found")
+    if identifier.is_builtin:
+        raise HTTPException(status_code=400, detail="Cannot delete built-in identifier")
+
+    await db.delete(identifier)
+    await db.commit()

--- a/server/api/response_rules.py
+++ b/server/api/response_rules.py
@@ -1,0 +1,168 @@
+"""Response Rule CRUD endpoints (P2-T5).
+
+Endpoints:
+  GET    /api/response-rules       — List response rules
+  POST   /api/response-rules       — Create response rule
+  GET    /api/response-rules/{id}  — Get response rule
+  PUT    /api/response-rules/{id}  — Update response rule
+  DELETE /api/response-rules/{id}  — Delete response rule
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from server.api.dependencies import RequirePermission
+from server.database import get_db
+from server.models.response import ResponseAction, ResponseRule
+from server.schemas.response import ResponseRuleCreate, ResponseRuleResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/response-rules", tags=["response-rules"])
+
+
+@router.get("", response_model=list[ResponseRuleResponse])
+async def list_response_rules(
+    user=Depends(RequirePermission("policies:read")),
+    db: AsyncSession = Depends(get_db),
+):
+    """List all response rules with their actions."""
+    stmt = (
+        select(ResponseRule)
+        .options(selectinload(ResponseRule.actions))
+        .order_by(ResponseRule.name)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+@router.post("", response_model=ResponseRuleResponse, status_code=status.HTTP_201_CREATED)
+async def create_response_rule(
+    body: ResponseRuleCreate,
+    user=Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a response rule with actions."""
+    rule = ResponseRule(name=body.name, description=body.description)
+    db.add(rule)
+    await db.flush()
+
+    for action_data in body.actions:
+        action = ResponseAction(
+            response_rule_id=rule.id,
+            action_type=action_data.action_type,
+            config=action_data.config,
+            order=action_data.order,
+        )
+        db.add(action)
+
+    await db.commit()
+
+    # Reload with actions
+    stmt = (
+        select(ResponseRule)
+        .where(ResponseRule.id == rule.id)
+        .options(selectinload(ResponseRule.actions))
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one()
+
+
+@router.get("/{rule_id}", response_model=ResponseRuleResponse)
+async def get_response_rule(
+    rule_id: uuid.UUID,
+    user=Depends(RequirePermission("policies:read")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get a response rule by ID."""
+    stmt = (
+        select(ResponseRule)
+        .where(ResponseRule.id == rule_id)
+        .options(selectinload(ResponseRule.actions))
+    )
+    result = await db.execute(stmt)
+    rule = result.scalar_one_or_none()
+    if not rule:
+        raise HTTPException(status_code=404, detail="Response rule not found")
+    return rule
+
+
+@router.put("/{rule_id}", response_model=ResponseRuleResponse)
+async def update_response_rule(
+    rule_id: uuid.UUID,
+    body: ResponseRuleCreate,
+    user=Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update a response rule (replaces actions)."""
+    stmt = (
+        select(ResponseRule)
+        .where(ResponseRule.id == rule_id)
+        .options(selectinload(ResponseRule.actions))
+    )
+    result = await db.execute(stmt)
+    rule = result.scalar_one_or_none()
+    if not rule:
+        raise HTTPException(status_code=404, detail="Response rule not found")
+
+    rule_id = rule.id
+
+    # Delete old actions explicitly via SQL
+    from sqlalchemy import delete as sa_delete
+    await db.execute(
+        sa_delete(ResponseAction).where(ResponseAction.response_rule_id == rule_id)
+    )
+
+    # Update rule scalar fields via SQL to avoid stale ORM state
+    from sqlalchemy import update as sa_update
+    await db.execute(
+        sa_update(ResponseRule)
+        .where(ResponseRule.id == rule_id)
+        .values(name=body.name, description=body.description)
+    )
+
+    # Add new actions
+    for action_data in body.actions:
+        action = ResponseAction(
+            response_rule_id=rule_id,
+            action_type=action_data.action_type,
+            config=action_data.config,
+            order=action_data.order,
+        )
+        db.add(action)
+
+    await db.commit()
+
+    # Expire all to force reload, then fetch fresh
+    db.expunge_all()
+    result = await db.execute(
+        select(ResponseRule)
+        .where(ResponseRule.id == rule_id)
+        .options(selectinload(ResponseRule.actions))
+    )
+    return result.scalar_one()
+
+
+@router.delete("/{rule_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_response_rule(
+    rule_id: uuid.UUID,
+    user=Depends(RequirePermission("policies:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a response rule."""
+    result = await db.execute(
+        select(ResponseRule).where(ResponseRule.id == rule_id)
+    )
+    rule = result.scalar_one_or_none()
+    if not rule:
+        raise HTTPException(status_code=404, detail="Response rule not found")
+
+    await db.delete(rule)
+    await db.commit()

--- a/server/api/search.py
+++ b/server/api/search.py
@@ -1,0 +1,122 @@
+"""Global search endpoint (P2-T5).
+
+Endpoint:
+  GET /api/search?q=<term> — Search across incidents, policies, users
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.api.dependencies import RequirePermission
+from server.database import get_db
+from server.models.auth import User
+from server.models.incident import Incident
+from server.models.policy import Policy
+from server.schemas.base import CamelModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/search", tags=["search"])
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class SearchHit(CamelModel):
+    id: str
+    type: str  # "incident", "policy", "user"
+    title: str
+    subtitle: str | None = None
+
+
+class SearchResponse(CamelModel):
+    query: str
+    total: int
+    results: list[SearchHit]
+
+
+# ---------------------------------------------------------------------------
+# Search endpoint
+# ---------------------------------------------------------------------------
+
+MAX_RESULTS_PER_TYPE = 10
+
+
+@router.get("", response_model=SearchResponse)
+async def global_search(
+    q: str = Query(min_length=1, max_length=200),
+    user=Depends(RequirePermission("incidents:read")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Search across incidents, policies, and users.
+
+    Returns grouped results with type labels.
+    """
+    term = f"%{q}%"
+    results: list[SearchHit] = []
+
+    # Search incidents
+    stmt = (
+        select(Incident)
+        .where(
+            Incident.policy_name.ilike(term)
+            | Incident.file_name.ilike(term)
+            | Incident.user.ilike(term)
+        )
+        .limit(MAX_RESULTS_PER_TYPE)
+    )
+    for inc in (await db.execute(stmt)).scalars():
+        results.append(SearchHit(
+            id=str(inc.id),
+            type="incident",
+            title=f"{inc.policy_name} — {inc.severity.value.upper()}",
+            subtitle=f"{inc.file_name or 'N/A'} | {inc.user or 'N/A'} | {inc.status.value}",
+        ))
+
+    # Search policies (non-templates)
+    stmt = (
+        select(Policy)
+        .where(
+            Policy.is_template == False,  # noqa: E712
+            Policy.name.ilike(term) | Policy.description.ilike(term),
+        )
+        .limit(MAX_RESULTS_PER_TYPE)
+    )
+    for pol in (await db.execute(stmt)).scalars():
+        results.append(SearchHit(
+            id=str(pol.id),
+            type="policy",
+            title=pol.name,
+            subtitle=f"{pol.status.value} | {pol.severity.value}",
+        ))
+
+    # Search users
+    stmt = (
+        select(User)
+        .where(
+            User.username.ilike(term)
+            | User.email.ilike(term)
+            | User.full_name.ilike(term)
+        )
+        .limit(MAX_RESULTS_PER_TYPE)
+    )
+    for u in (await db.execute(stmt)).scalars():
+        results.append(SearchHit(
+            id=str(u.id),
+            type="user",
+            title=u.username,
+            subtitle=u.full_name or u.email,
+        ))
+
+    return SearchResponse(
+        query=q,
+        total=len(results),
+        results=results,
+    )

--- a/server/api/system.py
+++ b/server/api/system.py
@@ -1,0 +1,88 @@
+"""System endpoints — health, audit log (P2-T5).
+
+Endpoints:
+  GET /api/health       — Health check (already in main.py)
+  GET /api/audit-log    — List audit log entries
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.api.dependencies import RequirePermission
+from server.database import get_db
+from server.models.audit import AuditLog
+from server.schemas.base import CamelModel, PaginatedResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api", tags=["system"])
+
+
+# ---------------------------------------------------------------------------
+# Audit log schemas
+# ---------------------------------------------------------------------------
+
+
+class AuditLogResponse(CamelModel):
+    id: uuid.UUID
+    actor_id: uuid.UUID | None
+    action: str
+    resource_type: str
+    resource_id: str | None
+    detail: str | None
+    changes: dict | None
+    ip_address: str | None
+    created_at: datetime
+
+
+class AuditLogListResponse(PaginatedResponse):
+    items: list[AuditLogResponse]
+
+
+# ---------------------------------------------------------------------------
+# Audit log endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get("/audit-log", response_model=AuditLogListResponse)
+async def list_audit_log(
+    user=Depends(RequirePermission("system:admin")),
+    db: AsyncSession = Depends(get_db),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=25, ge=1, le=100),
+    resource_type: str | None = Query(default=None),
+    action: str | None = Query(default=None),
+):
+    """List audit log entries (admin only)."""
+    base = select(AuditLog)
+
+    if resource_type:
+        base = base.where(AuditLog.resource_type == resource_type)
+    if action:
+        base = base.where(AuditLog.action.ilike(f"%{action}%"))
+
+    # Count
+    count_stmt = select(func.count()).select_from(base.subquery())
+    total = (await db.execute(count_stmt)).scalar() or 0
+
+    # Paginate
+    offset = (page - 1) * page_size
+    stmt = base.order_by(AuditLog.created_at.desc()).offset(offset).limit(page_size)
+    result = await db.execute(stmt)
+    entries = list(result.scalars().all())
+
+    return AuditLogListResponse(
+        items=entries,
+        total=total,
+        page=page,
+        page_size=page_size,
+        pages=max(1, math.ceil(total / page_size)),
+    )

--- a/server/api/users.py
+++ b/server/api/users.py
@@ -1,0 +1,187 @@
+"""User and Role management endpoints (P2-T5).
+
+Endpoints:
+  GET    /api/users         — List users
+  POST   /api/users         — Create user
+  GET    /api/users/{id}    — Get user
+  PUT    /api/users/{id}    — Update user
+  GET    /api/roles         — List roles (already in auth.py, this is an alias)
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from server.api.dependencies import RequirePermission
+from server.database import get_db
+from server.models.auth import Role, User
+from server.schemas.auth import UserCreate, UserResponse, UserUpdate
+from server.services import auth_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/users", tags=["users"])
+
+
+@router.get("", response_model=list[UserResponse])
+async def list_users(
+    user=Depends(RequirePermission("users:read")),
+    db: AsyncSession = Depends(get_db),
+):
+    """List all users."""
+    stmt = select(User).options(selectinload(User.role)).order_by(User.username)
+    result = await db.execute(stmt)
+    users = result.scalars().all()
+    return [
+        UserResponse(
+            id=u.id,
+            username=u.username,
+            email=u.email,
+            full_name=u.full_name,
+            is_active=u.is_active,
+            mfa_enabled=u.mfa_enabled,
+            role_id=u.role_id,
+            role_name=u.role.name if u.role else None,
+            created_at=u.created_at,
+            updated_at=u.updated_at,
+        )
+        for u in users
+    ]
+
+
+@router.post("", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+async def create_user(
+    body: UserCreate,
+    user=Depends(RequirePermission("users:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new user."""
+    # Check uniqueness
+    existing = await db.execute(
+        select(User).where(User.username == body.username)
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(status_code=409, detail=f"Username '{body.username}' already exists")
+
+    # Verify role exists
+    role = await db.execute(select(Role).where(Role.id == body.role_id))
+    if not role.scalar_one_or_none():
+        raise HTTPException(status_code=400, detail="Role not found")
+
+    new_user = User(
+        username=body.username,
+        email=body.email,
+        password_hash=auth_service.hash_password(body.password),
+        full_name=body.full_name,
+        is_active=True,
+        mfa_enabled=False,
+        role_id=body.role_id,
+    )
+    db.add(new_user)
+    await db.commit()
+
+    # Reload with role
+    stmt = (
+        select(User)
+        .where(User.id == new_user.id)
+        .options(selectinload(User.role))
+    )
+    result = await db.execute(stmt)
+    u = result.scalar_one()
+    return UserResponse(
+        id=u.id,
+        username=u.username,
+        email=u.email,
+        full_name=u.full_name,
+        is_active=u.is_active,
+        mfa_enabled=u.mfa_enabled,
+        role_id=u.role_id,
+        role_name=u.role.name if u.role else None,
+        created_at=u.created_at,
+        updated_at=u.updated_at,
+    )
+
+
+@router.get("/{user_id}", response_model=UserResponse)
+async def get_user(
+    user_id: uuid.UUID,
+    user=Depends(RequirePermission("users:read")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get a user by ID."""
+    stmt = (
+        select(User)
+        .where(User.id == user_id)
+        .options(selectinload(User.role))
+    )
+    result = await db.execute(stmt)
+    u = result.scalar_one_or_none()
+    if not u:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    return UserResponse(
+        id=u.id,
+        username=u.username,
+        email=u.email,
+        full_name=u.full_name,
+        is_active=u.is_active,
+        mfa_enabled=u.mfa_enabled,
+        role_id=u.role_id,
+        role_name=u.role.name if u.role else None,
+        created_at=u.created_at,
+        updated_at=u.updated_at,
+    )
+
+
+@router.put("/{user_id}", response_model=UserResponse)
+async def update_user(
+    user_id: uuid.UUID,
+    body: UserUpdate,
+    user=Depends(RequirePermission("users:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update user fields (email, name, active status, role)."""
+    stmt = (
+        select(User)
+        .where(User.id == user_id)
+        .options(selectinload(User.role))
+    )
+    result = await db.execute(stmt)
+    u = result.scalar_one_or_none()
+    if not u:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    update_data = body.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(u, key, value)
+
+    await db.commit()
+    await db.refresh(u)
+
+    # Reload role relationship
+    stmt = (
+        select(User)
+        .where(User.id == u.id)
+        .options(selectinload(User.role))
+    )
+    result = await db.execute(stmt)
+    u = result.scalar_one()
+
+    return UserResponse(
+        id=u.id,
+        username=u.username,
+        email=u.email,
+        full_name=u.full_name,
+        is_active=u.is_active,
+        mfa_enabled=u.mfa_enabled,
+        role_id=u.role_id,
+        role_name=u.role.name if u.role else None,
+        created_at=u.created_at,
+        updated_at=u.updated_at,
+    )

--- a/server/main.py
+++ b/server/main.py
@@ -6,8 +6,14 @@ from fastapi.middleware.cors import CORSMiddleware
 from server.config import settings
 from server.api.auth import router as auth_router
 from server.api.detection import router as detection_router
+from server.api.dictionaries import router as dictionaries_router
+from server.api.identifiers import router as identifiers_router
 from server.api.incidents import router as incidents_router
 from server.api.policies import router as policies_router
+from server.api.response_rules import router as response_rules_router
+from server.api.search import router as search_router
+from server.api.system import router as system_router
+from server.api.users import router as users_router
 
 
 @asynccontextmanager
@@ -35,8 +41,14 @@ app.add_middleware(
 # --- Routers ---
 app.include_router(auth_router)
 app.include_router(detection_router)
+app.include_router(dictionaries_router)
+app.include_router(identifiers_router)
 app.include_router(incidents_router)
 app.include_router(policies_router)
+app.include_router(response_rules_router)
+app.include_router(search_router)
+app.include_router(system_router)
+app.include_router(users_router)
 
 
 @app.get("/api/health")

--- a/tests/api/test_supporting.py
+++ b/tests/api/test_supporting.py
@@ -1,0 +1,545 @@
+"""Tests for supporting endpoints (P2-T5).
+
+Covers: data identifiers, keyword dictionaries, response rules,
+users, audit log, and global search.
+
+Uses SQLite in-memory database with PostgreSQL type compilation.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from server.api.dependencies import login_rate_limiter
+from server.database import get_db
+from server.main import app
+from server.models.auth import Role, User
+from server.models.base import Base
+from server.models.detection import DataIdentifier
+from server.models.incident import Channel, Incident, IncidentStatus
+from server.models.policy import Policy, PolicyStatus, Severity
+from server.services import auth_service
+
+# ---------------------------------------------------------------------------
+# SQLite ↔ PostgreSQL type compilation
+# ---------------------------------------------------------------------------
+
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
+from sqlalchemy.ext.compiler import compiles
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_sqlite(type_, compiler, **kw):
+    return "TEXT"
+
+
+@compiles(PG_UUID, "sqlite")
+def _compile_uuid_sqlite(type_, compiler, **kw):
+    return "VARCHAR(36)"
+
+
+# ---------------------------------------------------------------------------
+# Test database setup
+# ---------------------------------------------------------------------------
+
+TEST_DB_URL = "sqlite+aiosqlite:///file::memory:?cache=shared&uri=true"
+
+test_engine = create_async_engine(TEST_DB_URL, echo=False)
+TestSessionLocal = async_sessionmaker(
+    test_engine, class_=AsyncSession, expire_on_commit=False
+)
+
+
+@event.listens_for(test_engine.sync_engine, "connect")
+def _set_sqlite_pragma(dbapi_conn, connection_record):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA journal_mode=WAL")
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+async def override_get_db():
+    async with TestSessionLocal() as session:
+        yield session
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+# All tables needed
+ALL_TABLES = list(Base.metadata.tables.values())
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_admin_role_id = None
+_analyst_role_id = None
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def setup_db():
+    global _admin_role_id, _analyst_role_id
+
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all, tables=ALL_TABLES)
+
+    async with TestSessionLocal() as db:
+        # Roles
+        _admin_role_id = uuid.uuid4()
+        _analyst_role_id = uuid.uuid4()
+        remediator_role_id = uuid.uuid4()
+
+        admin_role = Role(id=_admin_role_id, name="Admin", description="Full access")
+        analyst_role = Role(id=_analyst_role_id, name="Analyst", description="Read+detect")
+        remediator_role = Role(id=remediator_role_id, name="Remediator", description="Incidents only")
+        db.add_all([admin_role, analyst_role, remediator_role])
+        await db.flush()
+
+        # Users
+        admin_user = User(
+            id=uuid.uuid4(), username="admin", email="admin@sentinel.local",
+            password_hash=auth_service.hash_password("SentinelDLP2026!"),
+            full_name="Admin User", is_active=True, mfa_enabled=False, role_id=_admin_role_id,
+        )
+        analyst_user = User(
+            id=uuid.uuid4(), username="analyst", email="analyst@sentinel.local",
+            password_hash=auth_service.hash_password("AnalystPass123!"),
+            full_name="Analyst User", is_active=True, mfa_enabled=False, role_id=_analyst_role_id,
+        )
+        db.add_all([admin_user, analyst_user])
+        await db.flush()
+
+        # Seed a built-in data identifier
+        builtin_id = DataIdentifier(
+            id=uuid.uuid4(), name="Credit Card Number (Built-in)",
+            description="Built-in CC detector",
+            config={"pattern": r"\b4[0-9]{12}\b", "validator": "luhn"},
+            is_builtin=True, is_active=True,
+        )
+        db.add(builtin_id)
+
+        # Seed an incident and a policy for search tests
+        policy = Policy(
+            id=uuid.uuid4(), name="PCI-DSS Test Policy",
+            description="Test policy for search", status=PolicyStatus.ACTIVE,
+            severity=Severity.HIGH, is_template=False, ttd_fallback="block",
+        )
+        db.add(policy)
+
+        incident = Incident(
+            id=uuid.uuid4(), policy_name="PCI-DSS Test Policy",
+            severity=Severity.HIGH, status=IncidentStatus.NEW,
+            channel=Channel.USB, source_type="endpoint",
+            file_name="data.xlsx", user="john.doe",
+            match_count=3, action_taken="block",
+        )
+        db.add(incident)
+
+        await db.commit()
+
+    yield
+
+    login_rate_limiter._buckets.clear()
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all, tables=ALL_TABLES)
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def admin_token(client: AsyncClient) -> str:
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "SentinelDLP2026!"},
+    )
+    return resp.json()["access_token"]
+
+
+@pytest_asyncio.fixture
+async def analyst_token(client: AsyncClient) -> str:
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "analyst", "password": "AnalystPass123!"},
+    )
+    return resp.json()["access_token"]
+
+
+def auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ===========================================================================
+# Data Identifiers
+# ===========================================================================
+
+
+class TestIdentifiers:
+    @pytest.mark.asyncio
+    async def test_list(self, client, admin_token):
+        resp = await client.get("/api/identifiers", headers=auth(admin_token))
+        assert resp.status_code == 200
+        assert len(resp.json()) >= 1
+
+    @pytest.mark.asyncio
+    async def test_create_custom(self, client, admin_token):
+        resp = await client.post(
+            "/api/identifiers",
+            json={"name": "Custom SSN", "config": {"pattern": r"\d{3}-\d{2}-\d{4}", "validator": "ssn_area"}},
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "Custom SSN"
+        assert resp.json()["is_builtin"] is False
+
+    @pytest.mark.asyncio
+    async def test_get(self, client, admin_token):
+        # Create then get
+        created = await client.post(
+            "/api/identifiers",
+            json={"name": "Get Test", "config": {"pattern": "test"}},
+            headers=auth(admin_token),
+        )
+        iid = created.json()["id"]
+        resp = await client.get(f"/api/identifiers/{iid}", headers=auth(admin_token))
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Get Test"
+
+    @pytest.mark.asyncio
+    async def test_update(self, client, admin_token):
+        created = await client.post(
+            "/api/identifiers",
+            json={"name": "Update Me", "config": {"pattern": "old"}},
+            headers=auth(admin_token),
+        )
+        iid = created.json()["id"]
+        resp = await client.put(
+            f"/api/identifiers/{iid}",
+            json={"name": "Updated", "config": {"pattern": "new"}},
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Updated"
+
+    @pytest.mark.asyncio
+    async def test_delete_custom(self, client, admin_token):
+        created = await client.post(
+            "/api/identifiers",
+            json={"name": "Delete Me", "config": {"pattern": "x"}},
+            headers=auth(admin_token),
+        )
+        iid = created.json()["id"]
+        resp = await client.delete(f"/api/identifiers/{iid}", headers=auth(admin_token))
+        assert resp.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_cannot_delete_builtin(self, client, admin_token):
+        resp = await client.get("/api/identifiers", headers=auth(admin_token))
+        builtin = next(i for i in resp.json() if i["is_builtin"])
+        resp = await client.delete(
+            f"/api/identifiers/{builtin['id']}", headers=auth(admin_token)
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_duplicate_name_409(self, client, admin_token):
+        await client.post(
+            "/api/identifiers",
+            json={"name": "Unique", "config": {"pattern": "x"}},
+            headers=auth(admin_token),
+        )
+        resp = await client.post(
+            "/api/identifiers",
+            json={"name": "Unique", "config": {"pattern": "y"}},
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 409
+
+
+# ===========================================================================
+# Keyword Dictionaries
+# ===========================================================================
+
+
+class TestDictionaries:
+    @pytest.mark.asyncio
+    async def test_crud_lifecycle(self, client, admin_token):
+        """Create → get → update → delete."""
+        # Create
+        resp = await client.post(
+            "/api/dictionaries",
+            json={"name": "Financial Terms", "config": {"keywords": ["revenue", "profit", "loss"]}},
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 201
+        did = resp.json()["id"]
+
+        # Get
+        resp = await client.get(f"/api/dictionaries/{did}", headers=auth(admin_token))
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Financial Terms"
+
+        # Update
+        resp = await client.put(
+            f"/api/dictionaries/{did}",
+            json={"name": "Financial Terms v2", "config": {"keywords": ["revenue", "profit", "loss", "margin"]}},
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Financial Terms v2"
+
+        # Delete
+        resp = await client.delete(f"/api/dictionaries/{did}", headers=auth(admin_token))
+        assert resp.status_code == 204
+
+        # Verify gone
+        resp = await client.get(f"/api/dictionaries/{did}", headers=auth(admin_token))
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_list_empty(self, client, admin_token):
+        resp = await client.get("/api/dictionaries", headers=auth(admin_token))
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+
+# ===========================================================================
+# Response Rules
+# ===========================================================================
+
+
+class TestResponseRules:
+    @pytest.mark.asyncio
+    async def test_create_with_actions(self, client, admin_token):
+        resp = await client.post(
+            "/api/response-rules",
+            json={
+                "name": "Block and Notify",
+                "description": "Block file and notify user",
+                "actions": [
+                    {"action_type": "block", "config": {"recovery_path": "/tmp"}, "order": 0},
+                    {"action_type": "notify", "config": {"message": "Blocked!"}, "order": 1},
+                ],
+            },
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == "Block and Notify"
+        assert len(data["actions"]) == 2
+        assert data["actions"][0]["action_type"] == "block"
+
+    @pytest.mark.asyncio
+    async def test_list(self, client, admin_token):
+        await client.post(
+            "/api/response-rules",
+            json={"name": "List Test", "actions": []},
+            headers=auth(admin_token),
+        )
+        resp = await client.get("/api/response-rules", headers=auth(admin_token))
+        assert resp.status_code == 200
+        assert len(resp.json()) >= 1
+
+    @pytest.mark.asyncio
+    async def test_update_replaces_actions(self, client, admin_token):
+        created = await client.post(
+            "/api/response-rules",
+            json={
+                "name": "Original",
+                "actions": [{"action_type": "log", "order": 0}],
+            },
+            headers=auth(admin_token),
+        )
+        rid = created.json()["id"]
+
+        resp = await client.put(
+            f"/api/response-rules/{rid}",
+            json={
+                "name": "Updated",
+                "actions": [
+                    {"action_type": "block", "order": 0},
+                    {"action_type": "notify", "config": {"msg": "hi"}, "order": 1},
+                ],
+            },
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Updated"
+        assert len(resp.json()["actions"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_delete(self, client, admin_token):
+        created = await client.post(
+            "/api/response-rules",
+            json={"name": "Delete Me", "actions": []},
+            headers=auth(admin_token),
+        )
+        rid = created.json()["id"]
+        resp = await client.delete(f"/api/response-rules/{rid}", headers=auth(admin_token))
+        assert resp.status_code == 204
+
+
+# ===========================================================================
+# Users
+# ===========================================================================
+
+
+class TestUsers:
+    @pytest.mark.asyncio
+    async def test_list_users(self, client, admin_token):
+        resp = await client.get("/api/users", headers=auth(admin_token))
+        assert resp.status_code == 200
+        users = resp.json()
+        assert len(users) >= 2
+        assert all("username" in u for u in users)
+
+    @pytest.mark.asyncio
+    async def test_create_user(self, client, admin_token):
+        resp = await client.post(
+            "/api/users",
+            json={
+                "username": "newuser",
+                "email": "newuser@example.com",
+                "password": "NewPass2026!",
+                "full_name": "New User",
+                "role_id": str(_analyst_role_id),
+            },
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["username"] == "newuser"
+        assert resp.json()["role_name"] == "Analyst"
+
+    @pytest.mark.asyncio
+    async def test_get_user(self, client, admin_token):
+        # List to get an ID
+        resp = await client.get("/api/users", headers=auth(admin_token))
+        uid = resp.json()[0]["id"]
+
+        resp = await client.get(f"/api/users/{uid}", headers=auth(admin_token))
+        assert resp.status_code == 200
+        assert resp.json()["id"] == uid
+
+    @pytest.mark.asyncio
+    async def test_update_user(self, client, admin_token):
+        resp = await client.get("/api/users", headers=auth(admin_token))
+        uid = next(u["id"] for u in resp.json() if u["username"] == "analyst")
+
+        resp = await client.put(
+            f"/api/users/{uid}",
+            json={"full_name": "Updated Analyst"},
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["full_name"] == "Updated Analyst"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_username_409(self, client, admin_token):
+        resp = await client.post(
+            "/api/users",
+            json={
+                "username": "admin",  # already exists
+                "email": "dup@example.com",
+                "password": "DupPass2026!",
+                "role_id": str(_admin_role_id),
+            },
+            headers=auth(admin_token),
+        )
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_analyst_cannot_manage_users(self, client, analyst_token):
+        resp = await client.get("/api/users", headers=auth(analyst_token))
+        assert resp.status_code == 403
+
+
+# ===========================================================================
+# Audit Log
+# ===========================================================================
+
+
+class TestAuditLog:
+    @pytest.mark.asyncio
+    async def test_list_audit_log(self, client, admin_token):
+        # Generate an audit entry by creating an identifier
+        await client.post(
+            "/api/identifiers",
+            json={"name": "Audit Test", "config": {"pattern": "x"}},
+            headers=auth(admin_token),
+        )
+
+        resp = await client.get("/api/audit-log", headers=auth(admin_token))
+        assert resp.status_code == 200
+        # May or may not have entries depending on whether CRUD endpoints audit
+        assert "items" in resp.json()
+        assert "total" in resp.json()
+
+    @pytest.mark.asyncio
+    async def test_analyst_cannot_view_audit_log(self, client, analyst_token):
+        resp = await client.get("/api/audit-log", headers=auth(analyst_token))
+        assert resp.status_code == 403
+
+
+# ===========================================================================
+# Global Search
+# ===========================================================================
+
+
+class TestSearch:
+    @pytest.mark.asyncio
+    async def test_search_incidents(self, client, admin_token):
+        resp = await client.get("/api/search?q=john", headers=auth(admin_token))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] >= 1
+        assert any(r["type"] == "incident" for r in data["results"])
+
+    @pytest.mark.asyncio
+    async def test_search_policies(self, client, admin_token):
+        resp = await client.get("/api/search?q=PCI", headers=auth(admin_token))
+        assert resp.status_code == 200
+        data = resp.json()
+        # Should find the policy and/or incident
+        assert len(data["results"]) >= 1
+
+    @pytest.mark.asyncio
+    async def test_search_users(self, client, admin_token):
+        resp = await client.get("/api/search?q=admin", headers=auth(admin_token))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(r["type"] == "user" for r in data["results"])
+
+    @pytest.mark.asyncio
+    async def test_search_grouped_results(self, client, admin_token):
+        """Search returns results from multiple types."""
+        resp = await client.get("/api/search?q=PCI", headers=auth(admin_token))
+        data = resp.json()
+        types = {r["type"] for r in data["results"]}
+        # PCI matches both incident and policy
+        assert "incident" in types or "policy" in types
+
+    @pytest.mark.asyncio
+    async def test_search_no_results(self, client, admin_token):
+        resp = await client.get("/api/search?q=zzzznonexistent", headers=auth(admin_token))
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_search_requires_auth(self, client):
+        resp = await client.get("/api/search?q=test")
+        assert resp.status_code in (401, 403)


### PR DESCRIPTION
## Summary
Six new API routers completing the REST API surface:

- **`/api/identifiers`** — Data identifier CRUD. Custom identifiers can be created/updated/deleted; built-in identifiers are protected from deletion. Duplicate name returns 409.
- **`/api/dictionaries`** — Keyword dictionary CRUD with full lifecycle.
- **`/api/response-rules`** — Response rule CRUD with nested actions. Update replaces all actions atomically.
- **`/api/users`** — User management (list, create, get, update). Admin-only via `users:read`/`users:write`. Username uniqueness enforced.
- **`/api/audit-log`** — Paginated audit log with resource_type and action filters. Admin-only (`system:admin`).
- **`/api/search`** — Global search across incidents (policy_name, file_name, user), policies (name, description), and users (username, email, full_name). Returns grouped results with type labels.

## Acceptance Criteria
- ✅ All CRUD works (identifiers, dictionaries, response rules, users)
- ✅ Custom data identifier → created and retrievable
- ✅ Keyword dictionary → full lifecycle (create → get → update → delete → verify gone)
- ✅ Search returns grouped results across incidents/policies/users

## Test plan
- [x] 27 new tests in `test_supporting.py`
- [x] Full suite: 523 tests passing
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)