### PR TITLE
Add minifilter driver skeleton with FltRegisterFilter and comm port (P3-T2)

### DIFF
--- a/agent/driver/CMakeLists.txt
+++ b/agent/driver/CMakeLists.txt
@@ -1,0 +1,76 @@
+# ---------------------------------------------------------------------------
+# SentinelDLP Minifilter Driver
+# ---------------------------------------------------------------------------
+# This builds the kernel-mode minifilter driver (.sys) using WDK.
+#
+# NOTE: Kernel-mode drivers cannot be built with the standard CMake
+# MSVC generator in the same way as user-mode code. This CMakeLists
+# provides the source list and configuration for use with:
+#   1. The WDK MSBuild integration (Visual Studio)
+#   2. A separate WDK build environment
+#
+# For production builds, use the .vcxproj or the INF + WDK command line.
+# ---------------------------------------------------------------------------
+
+cmake_minimum_required(VERSION 3.20)
+
+set(DRIVER_NAME sentinel_dlp_filter)
+
+# Source files
+set(DRIVER_SOURCES
+    sentinel_dlp_filter.c
+    filter_comm.c
+)
+
+set(DRIVER_HEADERS
+    sentinel_dlp_filter.h
+)
+
+# INF file
+set(DRIVER_INF
+    sentinel_dlp_filter.inf
+)
+
+# ---------------------------------------------------------------------------
+# If WDK is available, try to build via wdk_add_driver
+# (provided by FindWDK.cmake in parent project)
+# ---------------------------------------------------------------------------
+if(COMMAND wdk_add_driver)
+    wdk_add_driver(${DRIVER_NAME}
+        ${DRIVER_SOURCES}
+        ${DRIVER_HEADERS}
+    )
+
+    target_compile_definitions(${DRIVER_NAME} PRIVATE
+        SENTINEL_DLP_DRIVER
+        POOL_NX_OPTIN=1
+    )
+
+    # Link against FltMgr (Filter Manager)
+    target_link_libraries(${DRIVER_NAME}
+        fltMgr
+    )
+
+    message(STATUS "Driver target '${DRIVER_NAME}' configured via WDK")
+
+elseif(WDK_FOUND)
+    # WDK found but no wdk_add_driver command — create a custom target
+    # that invokes MSBuild with WDK integration
+    message(STATUS "WDK found but wdk_add_driver not available.")
+    message(STATUS "Use Visual Studio or 'msbuild' to build the driver.")
+    message(STATUS "Driver sources: ${DRIVER_SOURCES}")
+
+    # Create a custom target so the sources show up in the IDE
+    add_custom_target(${DRIVER_NAME}_sources
+        SOURCES ${DRIVER_SOURCES} ${DRIVER_HEADERS} ${DRIVER_INF}
+    )
+
+else()
+    message(STATUS "WDK not found — driver build skipped.")
+    message(STATUS "Install the Windows Driver Kit to build the minifilter.")
+
+    # Still create a source-only target for IDE visibility
+    add_custom_target(${DRIVER_NAME}_sources
+        SOURCES ${DRIVER_SOURCES} ${DRIVER_HEADERS} ${DRIVER_INF}
+    )
+endif()

--- a/agent/driver/filter_comm.c
+++ b/agent/driver/filter_comm.c
@@ -1,0 +1,130 @@
+/*
+ * filter_comm.c
+ * SentinelDLP Minifilter Driver - Communication Port Handlers
+ *
+ * Handles user-mode connection, disconnection, and message processing
+ * over the filter communication port (\SentinelDLPPort).
+ */
+
+#include "sentinel_dlp_filter.h"
+
+/* ================================================================== */
+/*  Port Connect callback                                              */
+/* ================================================================== */
+
+NTSTATUS
+SentinelPortConnect(
+    _In_ PFLT_PORT ClientPort,
+    _In_opt_ PVOID ServerPortCookie,
+    _In_reads_bytes_opt_(SizeOfContext) PVOID ConnectionContext,
+    _In_ ULONG SizeOfContext,
+    _Outptr_result_maybenull_ PVOID *ConnectionCookie
+)
+{
+    UNREFERENCED_PARAMETER(ServerPortCookie);
+    UNREFERENCED_PARAMETER(ConnectionContext);
+    UNREFERENCED_PARAMETER(SizeOfContext);
+
+    /*
+     * Only allow one connection at a time.
+     * The DLP agent service is the sole consumer.
+     */
+    if (InterlockedIncrement(&gFilterData.ConnectionCount) > SENTINEL_DLP_MAX_CONNECTIONS) {
+        InterlockedDecrement(&gFilterData.ConnectionCount);
+        KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_WARNING_LEVEL,
+            "SentinelDLP: Connection rejected (max connections reached)\n"));
+        return STATUS_CONNECTION_REFUSED;
+    }
+
+    gFilterData.ClientPort = ClientPort;
+    gFilterData.ClientConnected = TRUE;
+    *ConnectionCookie = NULL;
+
+    KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL,
+        "SentinelDLP: User-mode client connected (PID: %lu)\n",
+        (ULONG)(ULONG_PTR)PsGetCurrentProcessId()));
+
+    return STATUS_SUCCESS;
+}
+
+/* ================================================================== */
+/*  Port Disconnect callback                                           */
+/* ================================================================== */
+
+VOID
+SentinelPortDisconnect(
+    _In_opt_ PVOID ConnectionCookie
+)
+{
+    UNREFERENCED_PARAMETER(ConnectionCookie);
+
+    KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL,
+        "SentinelDLP: User-mode client disconnected\n"));
+
+    /*
+     * Close the client port handle. This is required to properly
+     * tear down the connection.
+     */
+    FltCloseClientPort(gFilterData.Filter, &gFilterData.ClientPort);
+
+    gFilterData.ClientPort = NULL;
+    gFilterData.ClientConnected = FALSE;
+    InterlockedDecrement(&gFilterData.ConnectionCount);
+}
+
+/* ================================================================== */
+/*  Port Message handler (user-mode -> driver)                         */
+/* ================================================================== */
+
+NTSTATUS
+SentinelPortMessageNotify(
+    _In_opt_ PVOID PortCookie,
+    _In_reads_bytes_opt_(InputBufferLength) PVOID InputBuffer,
+    _In_ ULONG InputBufferLength,
+    _Out_writes_bytes_to_opt_(OutputBufferLength, *ReturnOutputBufferLength) PVOID OutputBuffer,
+    _In_ ULONG OutputBufferLength,
+    _Out_ PULONG ReturnOutputBufferLength
+)
+{
+    SENTINEL_MSG_TYPE msgType;
+
+    UNREFERENCED_PARAMETER(PortCookie);
+    UNREFERENCED_PARAMETER(OutputBuffer);
+    UNREFERENCED_PARAMETER(OutputBufferLength);
+
+    *ReturnOutputBufferLength = 0;
+
+    /*
+     * Validate input buffer.
+     * User-mode sends configuration commands via this channel.
+     */
+    if (InputBuffer == NULL || InputBufferLength < sizeof(SENTINEL_MSG_TYPE)) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    __try {
+        msgType = *(SENTINEL_MSG_TYPE *)InputBuffer;
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER) {
+        return STATUS_INVALID_USER_BUFFER;
+    }
+
+    switch (msgType) {
+    case SentinelMsgConfigUpdate:
+        KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL,
+            "SentinelDLP: Config update received from user-mode\n"));
+        /*
+         * Future: parse config payload to update monitoring settings,
+         * volume filters, PID exclusions, etc.
+         */
+        break;
+
+    default:
+        KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_WARNING_LEVEL,
+            "SentinelDLP: Unknown message type %d from user-mode\n",
+            msgType));
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    return STATUS_SUCCESS;
+}

--- a/agent/driver/sentinel_dlp_filter.c
+++ b/agent/driver/sentinel_dlp_filter.c
@@ -1,0 +1,673 @@
+/*
+ * sentinel_dlp_filter.c
+ * SentinelDLP Minifilter Driver - Core Implementation
+ *
+ * Registers with Filter Manager, intercepts IRP_MJ_WRITE (pre-op)
+ * and IRP_MJ_CREATE (post-op) on removable and network volumes.
+ * Communicates with user-mode DLP agent via filter communication port.
+ */
+
+#include "sentinel_dlp_filter.h"
+
+/* ------------------------------------------------------------------ */
+/*  Globals                                                            */
+/* ------------------------------------------------------------------ */
+
+SENTINEL_FILTER_DATA gFilterData = { 0 };
+
+/* ------------------------------------------------------------------ */
+/*  Context definitions                                                */
+/* ------------------------------------------------------------------ */
+
+static const FLT_CONTEXT_REGISTRATION ContextRegistration[] = {
+    {
+        FLT_INSTANCE_CONTEXT,
+        0,
+        NULL,           /* CleanupCallback */
+        sizeof(SENTINEL_INSTANCE_CONTEXT),
+        SENTINEL_DLP_POOL_TAG,
+        NULL,           /* Allocate */
+        NULL,           /* Free    */
+        NULL            /* Reserved */
+    },
+    { FLT_CONTEXT_END }
+};
+
+/* ------------------------------------------------------------------ */
+/*  Operation callbacks                                                */
+/* ------------------------------------------------------------------ */
+
+static const FLT_OPERATION_REGISTRATION OperationCallbacks[] = {
+    {
+        IRP_MJ_WRITE,
+        0,
+        SentinelPreWrite,       /* PreOperation  */
+        NULL                    /* PostOperation */
+    },
+    {
+        IRP_MJ_CREATE,
+        0,
+        NULL,                   /* PreOperation  */
+        SentinelPostCreate      /* PostOperation */
+    },
+    { IRP_MJ_OPERATION_END }
+};
+
+/* ------------------------------------------------------------------ */
+/*  Filter registration structure                                      */
+/* ------------------------------------------------------------------ */
+
+static const FLT_REGISTRATION FilterRegistration = {
+    sizeof(FLT_REGISTRATION),       /* Size             */
+    FLT_REGISTRATION_VERSION,       /* Version          */
+    0,                              /* Flags            */
+    ContextRegistration,            /* ContextRegistration */
+    OperationCallbacks,             /* OperationRegistration */
+    SentinelFilterUnload,           /* FilterUnloadCallback */
+    SentinelInstanceSetup,          /* InstanceSetupCallback */
+    NULL,                           /* InstanceQueryTeardown */
+    SentinelInstanceTeardownStart,  /* InstanceTeardownStart */
+    SentinelInstanceTeardownComplete, /* InstanceTeardownComplete */
+    NULL,                           /* GenerateFileName */
+    NULL,                           /* NormalizeNameComponent */
+    NULL,                           /* NormalizeContextCleanup */
+    NULL,                           /* TransactionNotification */
+    NULL,                           /* NormalizeNameComponentEx */
+    NULL                            /* SectionNotification */
+};
+
+/* ================================================================== */
+/*  DriverEntry                                                        */
+/* ================================================================== */
+
+NTSTATUS
+DriverEntry(
+    _In_ PDRIVER_OBJECT DriverObject,
+    _In_ PUNICODE_STRING RegistryPath
+)
+{
+    NTSTATUS status;
+    UNICODE_STRING portName;
+    OBJECT_ATTRIBUTES oa;
+    PSECURITY_DESCRIPTOR sd = NULL;
+
+    UNREFERENCED_PARAMETER(RegistryPath);
+
+    KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL,
+        "SentinelDLP: DriverEntry - loading minifilter\n"));
+
+    /*
+     * Step 1: Register the minifilter with Filter Manager.
+     */
+    status = FltRegisterFilter(
+        DriverObject,
+        &FilterRegistration,
+        &gFilterData.Filter
+    );
+
+    if (!NT_SUCCESS(status)) {
+        KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL,
+            "SentinelDLP: FltRegisterFilter failed: 0x%08X\n", status));
+        return status;
+    }
+
+    /*
+     * Step 2: Create the communication port so user-mode can connect.
+     *
+     * We use FltBuildDefaultSecurityDescriptor to create an SD that
+     * grants FLT_PORT_ALL_ACCESS to administrators only.
+     */
+    status = FltBuildDefaultSecurityDescriptor(
+        &sd,
+        FLT_PORT_ALL_ACCESS
+    );
+
+    if (!NT_SUCCESS(status)) {
+        KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL,
+            "SentinelDLP: FltBuildDefaultSecurityDescriptor failed: 0x%08X\n",
+            status));
+        goto cleanup_filter;
+    }
+
+    RtlInitUnicodeString(&portName, SENTINEL_DLP_PORT_NAME);
+
+    InitializeObjectAttributes(
+        &oa,
+        &portName,
+        OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
+        NULL,
+        sd
+    );
+
+    status = FltCreateCommunicationPort(
+        gFilterData.Filter,
+        &gFilterData.ServerPort,
+        &oa,
+        NULL,                       /* ServerPortCookie */
+        SentinelPortConnect,
+        SentinelPortDisconnect,
+        SentinelPortMessageNotify,
+        SENTINEL_DLP_MAX_CONNECTIONS
+    );
+
+    FltFreeSecurityDescriptor(sd);
+
+    if (!NT_SUCCESS(status)) {
+        KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL,
+            "SentinelDLP: FltCreateCommunicationPort failed: 0x%08X\n",
+            status));
+        goto cleanup_filter;
+    }
+
+    /*
+     * Step 3: Start filtering I/O.
+     */
+    status = FltStartFiltering(gFilterData.Filter);
+
+    if (!NT_SUCCESS(status)) {
+        KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL,
+            "SentinelDLP: FltStartFiltering failed: 0x%08X\n", status));
+        goto cleanup_port;
+    }
+
+    KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL,
+        "SentinelDLP: Minifilter loaded successfully (altitude %ws)\n",
+        SENTINEL_DLP_ALTITUDE));
+
+    return STATUS_SUCCESS;
+
+cleanup_port:
+    FltCloseCommunicationPort(gFilterData.ServerPort);
+    gFilterData.ServerPort = NULL;
+
+cleanup_filter:
+    FltUnregisterFilter(gFilterData.Filter);
+    gFilterData.Filter = NULL;
+
+    return status;
+}
+
+/* ================================================================== */
+/*  FilterUnload                                                       */
+/* ================================================================== */
+
+NTSTATUS
+SentinelFilterUnload(
+    _In_ FLT_FILTER_UNLOAD_FLAGS Flags
+)
+{
+    UNREFERENCED_PARAMETER(Flags);
+
+    KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL,
+        "SentinelDLP: Unloading minifilter\n"));
+
+    /* Close the communication port first (stops new connections) */
+    if (gFilterData.ServerPort != NULL) {
+        FltCloseCommunicationPort(gFilterData.ServerPort);
+        gFilterData.ServerPort = NULL;
+    }
+
+    /* Unregister the filter (detaches from all volumes) */
+    if (gFilterData.Filter != NULL) {
+        FltUnregisterFilter(gFilterData.Filter);
+        gFilterData.Filter = NULL;
+    }
+
+    KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL,
+        "SentinelDLP: Minifilter unloaded cleanly\n"));
+
+    return STATUS_SUCCESS;
+}
+
+/* ================================================================== */
+/*  Instance setup / teardown                                          */
+/* ================================================================== */
+
+NTSTATUS
+SentinelInstanceSetup(
+    _In_ PCFLT_RELATED_OBJECTS FltObjects,
+    _In_ FLT_INSTANCE_SETUP_FLAGS Flags,
+    _In_ DEVICE_TYPE VolumeDeviceType,
+    _In_ FLT_FILESYSTEM_TYPE VolumeFilesystemType
+)
+{
+    NTSTATUS status;
+    PSENTINEL_INSTANCE_CONTEXT instanceContext = NULL;
+    SENTINEL_VOLUME_TYPE volumeType;
+
+    UNREFERENCED_PARAMETER(Flags);
+
+    /* Skip non-disk filesystems (named pipes, mailslots, etc.) */
+    if (VolumeFilesystemType == FLT_FSTYPE_RAW ||
+        VolumeDeviceType == FILE_DEVICE_NETWORK_FILE_SYSTEM ||
+        VolumeDeviceType == FILE_DEVICE_CD_ROM ||
+        VolumeDeviceType == FILE_DEVICE_CD_ROM_FILE_SYSTEM) {
+
+        /*
+         * We still attach to network devices — classified separately.
+         * Only skip truly uninteresting types.
+         */
+        if (VolumeDeviceType == FILE_DEVICE_CD_ROM ||
+            VolumeDeviceType == FILE_DEVICE_CD_ROM_FILE_SYSTEM ||
+            VolumeFilesystemType == FLT_FSTYPE_RAW) {
+            return STATUS_FLT_DO_NOT_ATTACH;
+        }
+    }
+
+    /* Classify the volume type */
+    volumeType = SentinelClassifyVolume(FltObjects, VolumeDeviceType);
+
+    /* Allocate and set instance context */
+    status = FltAllocateContext(
+        FltObjects->Filter,
+        FLT_INSTANCE_CONTEXT,
+        sizeof(SENTINEL_INSTANCE_CONTEXT),
+        NonPagedPoolNx,
+        (PFLT_CONTEXT *)&instanceContext
+    );
+
+    if (!NT_SUCCESS(status)) {
+        KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_WARNING_LEVEL,
+            "SentinelDLP: Failed to allocate instance context: 0x%08X\n",
+            status));
+        /* Attach anyway but without context — we'll skip monitoring */
+        return STATUS_SUCCESS;
+    }
+
+    RtlZeroMemory(instanceContext, sizeof(SENTINEL_INSTANCE_CONTEXT));
+    instanceContext->VolumeType = volumeType;
+
+    /*
+     * Only monitor removable and network volumes by default.
+     * Fixed volumes are attached to but not actively monitored.
+     */
+    instanceContext->MonitorEnabled =
+        (volumeType == SentinelVolumeRemovable ||
+         volumeType == SentinelVolumeNetwork);
+
+    /* Store volume name for logging */
+    instanceContext->VolumeName.Buffer = instanceContext->VolumeNameBuffer;
+    instanceContext->VolumeName.MaximumLength = sizeof(instanceContext->VolumeNameBuffer);
+    instanceContext->VolumeName.Length = 0;
+
+    status = FltSetInstanceContext(
+        FltObjects->Instance,
+        FLT_SET_CONTEXT_KEEP_IF_EXISTS,
+        instanceContext,
+        NULL
+    );
+
+    /* Release our reference — FltMgr holds its own if set succeeded */
+    FltReleaseContext(instanceContext);
+
+    if (!NT_SUCCESS(status) && status != STATUS_FLT_CONTEXT_ALREADY_DEFINED) {
+        KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_WARNING_LEVEL,
+            "SentinelDLP: FltSetInstanceContext failed: 0x%08X\n", status));
+    }
+
+    KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL,
+        "SentinelDLP: Attached to volume (type=%d, monitor=%s)\n",
+        volumeType,
+        instanceContext->MonitorEnabled ? "YES" : "NO"));
+
+    return STATUS_SUCCESS;
+}
+
+VOID
+SentinelInstanceTeardownStart(
+    _In_ PCFLT_RELATED_OBJECTS FltObjects,
+    _In_ FLT_INSTANCE_TEARDOWN_FLAGS Reason
+)
+{
+    UNREFERENCED_PARAMETER(FltObjects);
+    UNREFERENCED_PARAMETER(Reason);
+
+    KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL,
+        "SentinelDLP: Instance teardown start\n"));
+}
+
+VOID
+SentinelInstanceTeardownComplete(
+    _In_ PCFLT_RELATED_OBJECTS FltObjects,
+    _In_ FLT_INSTANCE_TEARDOWN_FLAGS Reason
+)
+{
+    UNREFERENCED_PARAMETER(FltObjects);
+    UNREFERENCED_PARAMETER(Reason);
+
+    KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL,
+        "SentinelDLP: Instance teardown complete\n"));
+}
+
+/* ================================================================== */
+/*  Volume classification                                              */
+/* ================================================================== */
+
+SENTINEL_VOLUME_TYPE
+SentinelClassifyVolume(
+    _In_ PCFLT_RELATED_OBJECTS FltObjects,
+    _In_ DEVICE_TYPE VolumeDeviceType
+)
+{
+    NTSTATUS status;
+    PDEVICE_OBJECT deviceObject = NULL;
+
+    UNREFERENCED_PARAMETER(FltObjects);
+
+    /* Network filesystems */
+    if (VolumeDeviceType == FILE_DEVICE_NETWORK_FILE_SYSTEM ||
+        VolumeDeviceType == FILE_DEVICE_NETWORK) {
+        return SentinelVolumeNetwork;
+    }
+
+    /* Try to get the disk device to check characteristics */
+    status = FltGetDiskDeviceObject(FltObjects->Volume, &deviceObject);
+    if (NT_SUCCESS(status) && deviceObject != NULL) {
+        ULONG characteristics = deviceObject->Characteristics;
+        ObDereferenceObject(deviceObject);
+
+        if (characteristics & FILE_REMOVABLE_MEDIA) {
+            return SentinelVolumeRemovable;
+        }
+    }
+
+    /* Default: fixed volume */
+    if (VolumeDeviceType == FILE_DEVICE_DISK ||
+        VolumeDeviceType == FILE_DEVICE_DISK_FILE_SYSTEM) {
+        return SentinelVolumeFixed;
+    }
+
+    return SentinelVolumeUnknown;
+}
+
+/* ================================================================== */
+/*  IRP_MJ_WRITE pre-operation callback                                */
+/* ================================================================== */
+
+FLT_PREOP_CALLBACK_STATUS
+SentinelPreWrite(
+    _Inout_ PFLT_CALLBACK_DATA Data,
+    _In_ PCFLT_RELATED_OBJECTS FltObjects,
+    _Flt_CompletionContext_Outptr_ PVOID *CompletionContext
+)
+{
+    NTSTATUS status;
+    PSENTINEL_INSTANCE_CONTEXT instanceContext = NULL;
+    SENTINEL_MSG_TYPE verdict = SentinelMsgVerdictAllow;
+
+    *CompletionContext = NULL;
+
+    /*
+     * Fast path: if no user-mode client is connected, allow everything.
+     * We don't want to block I/O when the agent isn't running.
+     */
+    if (!gFilterData.ClientConnected) {
+        return FLT_PREOP_SUCCESS_NO_CALLBACK;
+    }
+
+    /* Get instance context to check if this volume is monitored */
+    status = FltGetInstanceContext(FltObjects->Instance, (PFLT_CONTEXT *)&instanceContext);
+    if (!NT_SUCCESS(status) || instanceContext == NULL) {
+        return FLT_PREOP_SUCCESS_NO_CALLBACK;
+    }
+
+    if (!instanceContext->MonitorEnabled) {
+        FltReleaseContext(instanceContext);
+        return FLT_PREOP_SUCCESS_NO_CALLBACK;
+    }
+
+    /*
+     * Skip kernel-mode originators (paging I/O, system threads).
+     * We only care about user-initiated writes.
+     */
+    if (Data->Iopb->IrpFlags & IRP_PAGING_IO) {
+        FltReleaseContext(instanceContext);
+        return FLT_PREOP_SUCCESS_NO_CALLBACK;
+    }
+
+    /*
+     * Send notification to user-mode and get verdict.
+     */
+    status = SentinelSendNotification(
+        FltObjects,
+        Data,
+        SentinelMsgFileWrite,
+        instanceContext,
+        &verdict
+    );
+
+    FltReleaseContext(instanceContext);
+
+    if (!NT_SUCCESS(status)) {
+        /* Communication failed — allow to prevent system hangs */
+        KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_WARNING_LEVEL,
+            "SentinelDLP: Notification failed (0x%08X), allowing write\n",
+            status));
+        return FLT_PREOP_SUCCESS_NO_CALLBACK;
+    }
+
+    /* Apply verdict */
+    if (verdict == SentinelMsgVerdictBlock) {
+        KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL,
+            "SentinelDLP: BLOCKED write by PID %lu\n",
+            (ULONG)(ULONG_PTR)PsGetCurrentProcessId()));
+
+        Data->IoStatus.Status = STATUS_ACCESS_DENIED;
+        Data->IoStatus.Information = 0;
+        return FLT_PREOP_COMPLETE;
+    }
+
+    /* SentinelMsgVerdictAllow or SentinelMsgVerdictScanFull (future) */
+    return FLT_PREOP_SUCCESS_NO_CALLBACK;
+}
+
+/* ================================================================== */
+/*  IRP_MJ_CREATE post-operation callback                              */
+/* ================================================================== */
+
+FLT_POSTOP_CALLBACK_STATUS
+SentinelPostCreate(
+    _Inout_ PFLT_CALLBACK_DATA Data,
+    _In_ PCFLT_RELATED_OBJECTS FltObjects,
+    _In_opt_ PVOID CompletionContext,
+    _In_ FLT_POST_OPERATION_FLAGS Flags
+)
+{
+    NTSTATUS status;
+    PSENTINEL_INSTANCE_CONTEXT instanceContext = NULL;
+    SENTINEL_MSG_TYPE verdict = SentinelMsgVerdictAllow;
+
+    UNREFERENCED_PARAMETER(CompletionContext);
+
+    /* Don't process if draining (volume being dismounted) */
+    if (FlagOn(Flags, FLTFL_POST_OPERATION_DRAINING)) {
+        return FLT_POSTOP_FINISHED_PROCESSING;
+    }
+
+    /* Only process successful creates */
+    if (!NT_SUCCESS(Data->IoStatus.Status)) {
+        return FLT_POSTOP_FINISHED_PROCESSING;
+    }
+
+    /* Skip if no client connected */
+    if (!gFilterData.ClientConnected) {
+        return FLT_POSTOP_FINISHED_PROCESSING;
+    }
+
+    /* Get instance context */
+    status = FltGetInstanceContext(FltObjects->Instance, (PFLT_CONTEXT *)&instanceContext);
+    if (!NT_SUCCESS(status) || instanceContext == NULL) {
+        return FLT_POSTOP_FINISHED_PROCESSING;
+    }
+
+    if (!instanceContext->MonitorEnabled) {
+        FltReleaseContext(instanceContext);
+        return FLT_POSTOP_FINISHED_PROCESSING;
+    }
+
+    /*
+     * Only track creates with write intent — these indicate a file
+     * is being opened for modification on a monitored volume.
+     */
+    if (!(Data->Iopb->Parameters.Create.SecurityContext->DesiredAccess &
+          (FILE_WRITE_DATA | FILE_APPEND_DATA))) {
+        FltReleaseContext(instanceContext);
+        return FLT_POSTOP_FINISHED_PROCESSING;
+    }
+
+    /*
+     * Notify user-mode of the create event (informational).
+     * We don't block creates — only writes.
+     */
+    status = SentinelSendNotification(
+        FltObjects,
+        Data,
+        SentinelMsgFileCreate,
+        instanceContext,
+        &verdict
+    );
+
+    FltReleaseContext(instanceContext);
+
+    /* Create post-ops are informational only — never block */
+    UNREFERENCED_PARAMETER(verdict);
+
+    return FLT_POSTOP_FINISHED_PROCESSING;
+}
+
+/* ================================================================== */
+/*  Send notification to user-mode                                     */
+/* ================================================================== */
+
+NTSTATUS
+SentinelSendNotification(
+    _In_ PCFLT_RELATED_OBJECTS FltObjects,
+    _In_ PFLT_CALLBACK_DATA Data,
+    _In_ SENTINEL_MSG_TYPE MsgType,
+    _In_ PSENTINEL_INSTANCE_CONTEXT InstanceContext,
+    _Out_ SENTINEL_MSG_TYPE *Verdict
+)
+{
+    NTSTATUS status;
+    PSENTINEL_NOTIFICATION notification = NULL;
+    SENTINEL_REPLY reply = { 0 };
+    ULONG replyLength = sizeof(SENTINEL_REPLY);
+    PFLT_FILE_NAME_INFORMATION nameInfo = NULL;
+    LARGE_INTEGER timeout;
+
+    *Verdict = SentinelMsgVerdictAllow;
+
+    /* Sanity: must have a client port */
+    if (gFilterData.ClientPort == NULL) {
+        return STATUS_PORT_DISCONNECTED;
+    }
+
+    /* Allocate notification from nonpaged pool (we're at IRQL <= APC) */
+    notification = (PSENTINEL_NOTIFICATION)ExAllocatePool2(
+        POOL_FLAG_NON_PAGED,
+        sizeof(SENTINEL_NOTIFICATION),
+        SENTINEL_DLP_POOL_TAG
+    );
+
+    if (notification == NULL) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    RtlZeroMemory(notification, sizeof(SENTINEL_NOTIFICATION));
+
+    /* Fill in the notification */
+    notification->Type = MsgType;
+    notification->ProcessId = (ULONG)(ULONG_PTR)PsGetCurrentProcessId();
+    notification->VolumeType = InstanceContext->VolumeType;
+
+    /* Get the file name */
+    status = FltGetFileNameInformation(
+        Data,
+        FLT_FILE_NAME_NORMALIZED | FLT_FILE_NAME_QUERY_DEFAULT,
+        &nameInfo
+    );
+
+    if (NT_SUCCESS(status)) {
+        FltParseFileNameInformation(nameInfo);
+
+        /* Copy file path (truncate if too long) */
+        ULONG copyLen = min(
+            nameInfo->Name.Length,
+            (SENTINEL_DLP_MAX_PATH - 1) * sizeof(WCHAR)
+        );
+        RtlCopyMemory(notification->FilePath, nameInfo->Name.Buffer, copyLen);
+        notification->FilePath[copyLen / sizeof(WCHAR)] = L'\0';
+
+        FltReleaseFileNameInformation(nameInfo);
+    }
+
+    /*
+     * For write operations, capture the first 4KB of content
+     * as a preview for quick pattern matching.
+     */
+    if (MsgType == SentinelMsgFileWrite &&
+        Data->Iopb->Parameters.Write.Length > 0 &&
+        Data->Iopb->Parameters.Write.WriteBuffer != NULL) {
+
+        ULONG previewLen = min(
+            Data->Iopb->Parameters.Write.Length,
+            SENTINEL_DLP_PREVIEW_SIZE
+        );
+
+        __try {
+            RtlCopyMemory(
+                notification->Content,
+                Data->Iopb->Parameters.Write.WriteBuffer,
+                previewLen
+            );
+            notification->ContentLength = previewLen;
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER) {
+            notification->ContentLength = 0;
+        }
+    }
+
+    /* Get file size (best effort) */
+    {
+        FILE_STANDARD_INFORMATION fileInfo;
+        status = FltQueryInformationFile(
+            FltObjects->Instance,
+            Data->Iopb->TargetFileObject,
+            &fileInfo,
+            sizeof(fileInfo),
+            FileStandardInformation,
+            NULL
+        );
+        if (NT_SUCCESS(status)) {
+            notification->FileSize = fileInfo.EndOfFile;
+        }
+    }
+
+    /*
+     * Send to user-mode with a 5-second timeout.
+     * This prevents blocking the I/O path if user-mode is hung.
+     */
+    timeout.QuadPart = -50000000LL;  /* 5 seconds in 100ns units */
+
+    status = FltSendMessage(
+        gFilterData.Filter,
+        &gFilterData.ClientPort,
+        notification,
+        sizeof(SENTINEL_NOTIFICATION),
+        &reply,
+        &replyLength,
+        &timeout
+    );
+
+    if (NT_SUCCESS(status) && replyLength >= sizeof(SENTINEL_REPLY)) {
+        *Verdict = reply.Verdict;
+    } else if (status == STATUS_TIMEOUT) {
+        KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_WARNING_LEVEL,
+            "SentinelDLP: Timeout waiting for user-mode reply, allowing\n"));
+        *Verdict = SentinelMsgVerdictAllow;
+        status = STATUS_SUCCESS;  /* Don't fail the I/O on timeout */
+    }
+
+    ExFreePoolWithTag(notification, SENTINEL_DLP_POOL_TAG);
+    return status;
+}

--- a/agent/driver/sentinel_dlp_filter.h
+++ b/agent/driver/sentinel_dlp_filter.h
@@ -1,0 +1,218 @@
+/*
+ * sentinel_dlp_filter.h
+ * SentinelDLP Minifilter Driver - Header
+ *
+ * Kernel-mode minifilter that intercepts file I/O on removable and
+ * network volumes, forwarding events to the user-mode DLP agent
+ * via a filter communication port.
+ *
+ * Altitude: 320100 (FSFilter Content Screener range 320000-329999)
+ */
+
+#pragma once
+
+#include <fltKernel.h>
+#include <dontuse.h>
+#include <suppress.h>
+#include <ntstrsafe.h>
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+#define SENTINEL_DLP_FILTER_NAME    L"SentinelDLPFilter"
+#define SENTINEL_DLP_PORT_NAME      L"\\SentinelDLPPort"
+#define SENTINEL_DLP_ALTITUDE       L"320100"
+#define SENTINEL_DLP_POOL_TAG       'plDS'   /* SDlp */
+
+/*
+ * Maximum number of concurrent user-mode connections.
+ * Only the DLP agent service should connect.
+ */
+#define SENTINEL_DLP_MAX_CONNECTIONS    1
+
+/* Maximum file path length we track */
+#define SENTINEL_DLP_MAX_PATH           1024
+
+/* Size of the content preview sent to user-mode (first 4KB) */
+#define SENTINEL_DLP_PREVIEW_SIZE       4096
+
+/* ------------------------------------------------------------------ */
+/*  Message types (driver <-> user-mode)                               */
+/* ------------------------------------------------------------------ */
+
+typedef enum _SENTINEL_MSG_TYPE {
+    SentinelMsgFileWrite = 1,       /* Driver -> UM: file write detected */
+    SentinelMsgFileCreate,          /* Driver -> UM: file create/open    */
+    SentinelMsgVerdictAllow,        /* UM -> Driver: allow the operation */
+    SentinelMsgVerdictBlock,        /* UM -> Driver: block the operation */
+    SentinelMsgVerdictScanFull,     /* UM -> Driver: pend, scan full     */
+    SentinelMsgScanResult,          /* UM -> Driver: scan complete       */
+    SentinelMsgConfigUpdate,        /* UM -> Driver: config change       */
+} SENTINEL_MSG_TYPE;
+
+/* ------------------------------------------------------------------ */
+/*  Volume type classification                                         */
+/* ------------------------------------------------------------------ */
+
+typedef enum _SENTINEL_VOLUME_TYPE {
+    SentinelVolumeFixed = 0,
+    SentinelVolumeRemovable,
+    SentinelVolumeNetwork,
+    SentinelVolumeUnknown,
+} SENTINEL_VOLUME_TYPE;
+
+/* ------------------------------------------------------------------ */
+/*  Messages exchanged over the communication port                     */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Notification sent from driver to user-mode when a file operation
+ * is intercepted on a monitored volume.
+ */
+#pragma pack(push, 1)
+typedef struct _SENTINEL_NOTIFICATION {
+    SENTINEL_MSG_TYPE   Type;
+    ULONG               ProcessId;
+    SENTINEL_VOLUME_TYPE VolumeType;
+    LARGE_INTEGER       FileSize;
+    ULONG               ContentLength;  /* Actual bytes in Content[] */
+    WCHAR               FilePath[SENTINEL_DLP_MAX_PATH];
+    UCHAR               Content[SENTINEL_DLP_PREVIEW_SIZE];
+} SENTINEL_NOTIFICATION, *PSENTINEL_NOTIFICATION;
+
+/*
+ * Reply from user-mode back to the driver.
+ */
+typedef struct _SENTINEL_REPLY {
+    SENTINEL_MSG_TYPE   Verdict;
+    ULONG               Reserved;
+} SENTINEL_REPLY, *PSENTINEL_REPLY;
+#pragma pack(pop)
+
+/* ------------------------------------------------------------------ */
+/*  Per-instance context (attached to each volume instance)            */
+/* ------------------------------------------------------------------ */
+
+typedef struct _SENTINEL_INSTANCE_CONTEXT {
+    SENTINEL_VOLUME_TYPE    VolumeType;
+    BOOLEAN                 MonitorEnabled;
+    UNICODE_STRING          VolumeName;
+    WCHAR                   VolumeNameBuffer[64];
+} SENTINEL_INSTANCE_CONTEXT, *PSENTINEL_INSTANCE_CONTEXT;
+
+/* ------------------------------------------------------------------ */
+/*  Global filter data                                                 */
+/* ------------------------------------------------------------------ */
+
+typedef struct _SENTINEL_FILTER_DATA {
+    PFLT_FILTER     Filter;
+    PFLT_PORT       ServerPort;
+    PFLT_PORT       ClientPort;
+    BOOLEAN         ClientConnected;
+    LONG            ConnectionCount;
+} SENTINEL_FILTER_DATA, *PSENTINEL_FILTER_DATA;
+
+extern SENTINEL_FILTER_DATA gFilterData;
+
+/* ------------------------------------------------------------------ */
+/*  Function prototypes - filter registration                          */
+/* ------------------------------------------------------------------ */
+
+DRIVER_INITIALIZE DriverEntry;
+NTSTATUS DriverEntry(
+    _In_ PDRIVER_OBJECT DriverObject,
+    _In_ PUNICODE_STRING RegistryPath
+);
+
+NTSTATUS
+SentinelFilterUnload(
+    _In_ FLT_FILTER_UNLOAD_FLAGS Flags
+);
+
+/* Instance setup/teardown */
+NTSTATUS
+SentinelInstanceSetup(
+    _In_ PCFLT_RELATED_OBJECTS FltObjects,
+    _In_ FLT_INSTANCE_SETUP_FLAGS Flags,
+    _In_ DEVICE_TYPE VolumeDeviceType,
+    _In_ FLT_FILESYSTEM_TYPE VolumeFilesystemType
+);
+
+VOID
+SentinelInstanceTeardownStart(
+    _In_ PCFLT_RELATED_OBJECTS FltObjects,
+    _In_ FLT_INSTANCE_TEARDOWN_FLAGS Reason
+);
+
+VOID
+SentinelInstanceTeardownComplete(
+    _In_ PCFLT_RELATED_OBJECTS FltObjects,
+    _In_ FLT_INSTANCE_TEARDOWN_FLAGS Reason
+);
+
+/* ------------------------------------------------------------------ */
+/*  Function prototypes - IRP callbacks                                */
+/* ------------------------------------------------------------------ */
+
+FLT_PREOP_CALLBACK_STATUS
+SentinelPreWrite(
+    _Inout_ PFLT_CALLBACK_DATA Data,
+    _In_ PCFLT_RELATED_OBJECTS FltObjects,
+    _Flt_CompletionContext_Outptr_ PVOID *CompletionContext
+);
+
+FLT_POSTOP_CALLBACK_STATUS
+SentinelPostCreate(
+    _Inout_ PFLT_CALLBACK_DATA Data,
+    _In_ PCFLT_RELATED_OBJECTS FltObjects,
+    _In_opt_ PVOID CompletionContext,
+    _In_ FLT_POST_OPERATION_FLAGS Flags
+);
+
+/* ------------------------------------------------------------------ */
+/*  Function prototypes - communication port                           */
+/* ------------------------------------------------------------------ */
+
+NTSTATUS
+SentinelPortConnect(
+    _In_ PFLT_PORT ClientPort,
+    _In_opt_ PVOID ServerPortCookie,
+    _In_reads_bytes_opt_(SizeOfContext) PVOID ConnectionContext,
+    _In_ ULONG SizeOfContext,
+    _Outptr_result_maybenull_ PVOID *ConnectionCookie
+);
+
+VOID
+SentinelPortDisconnect(
+    _In_opt_ PVOID ConnectionCookie
+);
+
+NTSTATUS
+SentinelPortMessageNotify(
+    _In_opt_ PVOID PortCookie,
+    _In_reads_bytes_opt_(InputBufferLength) PVOID InputBuffer,
+    _In_ ULONG InputBufferLength,
+    _Out_writes_bytes_to_opt_(OutputBufferLength, *ReturnOutputBufferLength) PVOID OutputBuffer,
+    _In_ ULONG OutputBufferLength,
+    _Out_ PULONG ReturnOutputBufferLength
+);
+
+/* ------------------------------------------------------------------ */
+/*  Function prototypes - helpers                                      */
+/* ------------------------------------------------------------------ */
+
+SENTINEL_VOLUME_TYPE
+SentinelClassifyVolume(
+    _In_ PCFLT_RELATED_OBJECTS FltObjects,
+    _In_ DEVICE_TYPE VolumeDeviceType
+);
+
+NTSTATUS
+SentinelSendNotification(
+    _In_ PCFLT_RELATED_OBJECTS FltObjects,
+    _In_ PFLT_CALLBACK_DATA Data,
+    _In_ SENTINEL_MSG_TYPE MsgType,
+    _In_ PSENTINEL_INSTANCE_CONTEXT InstanceContext,
+    _Out_ SENTINEL_MSG_TYPE *Verdict
+);

--- a/agent/driver/sentinel_dlp_filter.inf
+++ b/agent/driver/sentinel_dlp_filter.inf
@@ -1,0 +1,94 @@
+;;;
+;;; SentinelDLP Minifilter Driver
+;;; Content Screener - Altitude 320100
+;;;
+
+[Version]
+Signature   = "$Windows NT$"
+Class       = "ContentScreener"
+ClassGuid   = {3e3f0674-c83c-4558-bb26-9820e1eba5c5}
+Provider    = %ProviderString%
+DriverVer   = 03/18/2026,1.0.0.0
+CatalogFile = sentinel_dlp_filter.cat
+PnpLockdown = 1
+
+[DestinationDirs]
+DefaultDestDir          = 13
+SentinelDLPFilter.DriverFiles = 13
+
+;;; ===================================================================
+;;; Default install sections
+;;; ===================================================================
+
+[DefaultInstall.NTAMD64]
+OptionDesc  = %ServiceDescription%
+CopyFiles   = SentinelDLPFilter.DriverFiles
+
+[DefaultInstall.NTAMD64.Services]
+AddService  = %ServiceName%,,SentinelDLPFilter.Service
+
+;;; ===================================================================
+;;; Default uninstall sections
+;;; ===================================================================
+
+[DefaultUninstall.NTAMD64]
+LegacyUninstall = 1
+DelFiles        = SentinelDLPFilter.DriverFiles
+
+[DefaultUninstall.NTAMD64.Services]
+DelService = %ServiceName%,0x200
+
+;;; ===================================================================
+;;; Service configuration
+;;; ===================================================================
+
+[SentinelDLPFilter.Service]
+DisplayName    = %ServiceName%
+Description    = %ServiceDescription%
+ServiceBinary  = %13%\sentinel_dlp_filter.sys
+Dependencies   = "FltMgr"
+ServiceType    = 2                ; SERVICE_FILE_SYSTEM_DRIVER
+StartType      = 3                ; SERVICE_DEMAND_START
+ErrorControl   = 1                ; SERVICE_ERROR_NORMAL
+LoadOrderGroup = "FSFilter Content Screener"
+AddReg         = SentinelDLPFilter.AddRegistry
+
+;;; ===================================================================
+;;; Filter Manager registration
+;;; ===================================================================
+
+[SentinelDLPFilter.AddRegistry]
+HKR,"Instances","DefaultInstance",0x00000000,%DefaultInstance%
+HKR,"Instances\"%Instance1.Name%,"Altitude",0x00000000,%Instance1.Altitude%
+HKR,"Instances\"%Instance1.Name%,"Flags",0x00010001,%Instance1.Flags%
+
+;;; ===================================================================
+;;; File copy
+;;; ===================================================================
+
+[SentinelDLPFilter.DriverFiles]
+sentinel_dlp_filter.sys
+
+;;; ===================================================================
+;;; Source disk information
+;;; ===================================================================
+
+[SourceDisksFiles]
+sentinel_dlp_filter.sys = 1,,
+
+[SourceDisksNames]
+1 = %DiskId1%,,,
+
+;;; ===================================================================
+;;; String definitions
+;;; ===================================================================
+
+[Strings]
+ProviderString      = "Sentinel Security"
+ServiceName         = "SentinelDLPFilter"
+ServiceDescription  = "SentinelDLP Minifilter - File I/O content screening"
+DefaultInstance     = "SentinelDLP Instance"
+Instance1.Name      = "SentinelDLP Instance"
+Instance1.Altitude  = "320100"
+Instance1.Flags     = 0x0              ; Automatic attachment
+DiskId1             = "SentinelDLP Installation Disk"


### PR DESCRIPTION
## Summary
- Kernel-mode minifilter driver for SentinelDLP file I/O interception
- Registers at altitude 320100 (FSFilter Content Screener range)
- IRP_MJ_WRITE pre-op callback: intercepts writes on monitored volumes, sends notification to user-mode, applies ALLOW/BLOCK verdict
- IRP_MJ_CREATE post-op callback: tracks file opens with write intent (informational)
- Filter communication port (`\SentinelDLPPort`): single-connection, connect/disconnect/message handlers
- Volume classification: removable (USB), network (SMB/NFS), fixed (C:\) — only monitors removable + network
- Per-instance context with volume type and monitoring state
- 5-second timeout on FltSendMessage prevents I/O hangs if agent is unresponsive
- INF file for `fltmc load` / `fltmc unload` installation

## Files
- `agent/driver/sentinel_dlp_filter.h` — Header with types, constants, prototypes
- `agent/driver/sentinel_dlp_filter.c` — Core driver: DriverEntry, unload, instance setup, IRP callbacks, volume classification, notification sender
- `agent/driver/filter_comm.c` — Communication port: connect, disconnect, message handler
- `agent/driver/sentinel_dlp_filter.inf` — Driver installation INF
- `agent/driver/CMakeLists.txt` — Build integration (requires WDK)

## Note
This is kernel-mode C code. It cannot be compiled with the standard user-mode MSVC toolchain — requires WDK build environment. The code is structurally complete and follows the Windows minifilter framework patterns. Actual compilation and testing requires a WDK-configured build + test-signed driver loading on a test VM.

## Test plan
- [x] Code review: follows FltRegisterFilter → FltCreateCommunicationPort → FltStartFiltering pattern
- [x] Proper cleanup on failure (goto chains)
- [x] IRQL-safe: NonPagedPoolNx allocations, no paged pool in pre-op path
- [x] INF validates against minifilter installation requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)