### PR TITLE
Add data identifier validators and file type detector (P4-T3, P4-T4)

### DIFF
--- a/agent/CMakeLists.txt
+++ b/agent/CMakeLists.txt
@@ -127,6 +127,8 @@ add_executable(akeso-dlp-agent
     src/incident_queue.cpp
     src/detection/hs_regex_analyzer.cpp
     src/detection/keyword_analyzer.cpp
+    src/detection/validators.cpp
+    src/detection/file_type_detector.cpp
 )
 
 target_include_directories(akeso-dlp-agent PRIVATE
@@ -367,6 +369,40 @@ if(BUILD_TESTS)
             target_compile_definitions(test_keyword_analyzer PRIVATE HAS_SPDLOG)
         endif()
         add_test(NAME KeywordAnalyzerTests COMMAND test_keyword_analyzer)
+
+        # Validators tests
+        add_executable(test_validators
+            tests/test_validators.cpp
+            src/detection/validators.cpp
+        )
+        target_include_directories(test_validators PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+        )
+        target_link_libraries(test_validators PRIVATE
+            GTest::gtest_main
+        )
+        if(spdlog_FOUND)
+            target_link_libraries(test_validators PRIVATE spdlog::spdlog)
+            target_compile_definitions(test_validators PRIVATE HAS_SPDLOG)
+        endif()
+        add_test(NAME ValidatorTests COMMAND test_validators)
+
+        # FileTypeDetector tests
+        add_executable(test_file_type_detector
+            tests/test_file_type_detector.cpp
+            src/detection/file_type_detector.cpp
+        )
+        target_include_directories(test_file_type_detector PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+        )
+        target_link_libraries(test_file_type_detector PRIVATE
+            GTest::gtest_main
+        )
+        if(spdlog_FOUND)
+            target_link_libraries(test_file_type_detector PRIVATE spdlog::spdlog)
+            target_compile_definitions(test_file_type_detector PRIVATE HAS_SPDLOG)
+        endif()
+        add_test(NAME FileTypeDetectorTests COMMAND test_file_type_detector)
 
         message(STATUS "Testing enabled (GoogleTest found)")
     else()

--- a/agent/include/akeso/detection/file_type_detector.h
+++ b/agent/include/akeso/detection/file_type_detector.h
@@ -1,0 +1,108 @@
+/*
+ * file_type_detector.h
+ * AkesoDLP Agent - File Type Detection
+ *
+ * Magic byte signature matching for 50+ file types.
+ * No external dependency (no libmagic). Custom signature table
+ * covers Office, PDF, images, archives, executables, and scripts.
+ *
+ * Also supports file size thresholds and name pattern matching.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace akeso::dlp {
+
+/* ------------------------------------------------------------------ */
+/*  File categories                                                     */
+/* ------------------------------------------------------------------ */
+
+enum class FileCategory {
+    Unknown,
+    Document,       /* PDF, Office, RTF, plain text */
+    Spreadsheet,    /* Excel, CSV */
+    Presentation,   /* PowerPoint */
+    Image,          /* JPEG, PNG, GIF, BMP, TIFF, WebP, ICO, SVG */
+    Audio,          /* MP3, WAV, FLAC, OGG, AAC */
+    Video,          /* MP4, AVI, MKV, MOV, WebM, FLV */
+    Archive,        /* ZIP, RAR, 7z, TAR, GZ, BZ2, XZ, ZSTD */
+    Executable,     /* PE, ELF, Mach-O, DLL, MSI */
+    Script,         /* Python, JavaScript, PowerShell, Batch, Shell */
+    Database,       /* SQLite, MDB */
+    Font,           /* TTF, OTF, WOFF, WOFF2 */
+    CAD,            /* DWG */
+    Email,          /* EML, MSG */
+};
+
+/* ------------------------------------------------------------------ */
+/*  Detection result                                                    */
+/* ------------------------------------------------------------------ */
+
+struct FileTypeResult {
+    std::string   type_name;       /* e.g. "PDF", "JPEG", "PE Executable" */
+    std::string   mime_type;       /* e.g. "application/pdf" */
+    std::string   extension;       /* e.g. ".pdf" (canonical) */
+    FileCategory  category = FileCategory::Unknown;
+    int           confidence = 0;  /* 0-100 */
+};
+
+/* ------------------------------------------------------------------ */
+/*  Magic signature entry (internal)                                    */
+/* ------------------------------------------------------------------ */
+
+struct MagicSignature {
+    std::vector<uint8_t> magic;       /* Byte sequence to match */
+    size_t               offset;      /* Offset into file */
+    std::string          type_name;
+    std::string          mime_type;
+    std::string          extension;
+    FileCategory         category;
+    int                  confidence;  /* Base confidence for this sig */
+};
+
+/* ------------------------------------------------------------------ */
+/*  FileTypeDetector                                                    */
+/* ------------------------------------------------------------------ */
+
+class FileTypeDetector {
+public:
+    FileTypeDetector();
+
+    /*
+     * Detect file type from content bytes.
+     * Reads magic bytes from the buffer (first N bytes are sufficient;
+     * typically 16-64 bytes, up to 8192 for compound formats).
+     */
+    FileTypeResult DetectFromContent(const uint8_t* data, size_t length) const;
+    FileTypeResult DetectFromContent(const char* data, size_t length) const;
+
+    /*
+     * Detect file type from file name/extension.
+     * Lower confidence than content-based detection.
+     */
+    FileTypeResult DetectFromName(std::string_view filename) const;
+
+    /*
+     * Combined detection: content first, name as fallback/boost.
+     */
+    FileTypeResult Detect(const uint8_t* data, size_t length,
+                          std::string_view filename) const;
+
+    /* Number of registered signatures */
+    size_t SignatureCount() const { return signatures_.size(); }
+
+private:
+    void InitSignatures();
+    FileTypeResult CheckCompoundFormats(const uint8_t* data, size_t length) const;
+    static std::string ToLower(std::string_view s);
+    static std::string GetExtension(std::string_view filename);
+
+    std::vector<MagicSignature> signatures_;
+};
+
+}  // namespace akeso::dlp

--- a/agent/include/akeso/detection/validators.h
+++ b/agent/include/akeso/detection/validators.h
@@ -1,0 +1,85 @@
+/*
+ * validators.h
+ * AkesoDLP Agent - Data Identifier Validators
+ *
+ * Checksum and format validators for data identifiers detected by
+ * the regex and keyword analyzers. Reduces false positives by
+ * verifying structural correctness of matched patterns.
+ *
+ * Validators:
+ *   1. Credit Card      — Luhn algorithm
+ *   2. SSN              — Area/group number validation
+ *   3. IBAN             — MOD-97 checksum (ISO 13616)
+ *   4. ABA Routing      — 3-7-1 weighted checksum
+ *   5. US Phone         — Format validation
+ *   6. Email            — RFC 5321 simplified format
+ *   7. US Passport      — Format validation
+ *   8. US Driver License— State-aware format validation
+ *   9. IPv4             — Octet range validation
+ *  10. Date of Birth    — Calendar validity
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace akeso::dlp {
+
+/* ------------------------------------------------------------------ */
+/*  Validation result                                                   */
+/* ------------------------------------------------------------------ */
+
+enum class ValidationResult {
+    Valid,
+    Invalid,
+    Inconclusive,  /* Pattern matched but no checksum to verify */
+};
+
+/* ------------------------------------------------------------------ */
+/*  Validator functions                                                 */
+/* ------------------------------------------------------------------ */
+
+namespace validators {
+
+/* 1. Credit Card — Luhn algorithm */
+ValidationResult ValidateCreditCard(std::string_view input);
+
+/* 2. SSN — Area number must not be 000, 666, or 900-999 */
+ValidationResult ValidateSSN(std::string_view input);
+
+/* 3. IBAN — MOD-97 checksum (ISO 13616) */
+ValidationResult ValidateIBAN(std::string_view input);
+
+/* 4. ABA Routing Number — 3-7-1 weighted checksum */
+ValidationResult ValidateABA(std::string_view input);
+
+/* 5. US Phone — 10-digit format, area code validation */
+ValidationResult ValidateUSPhone(std::string_view input);
+
+/* 6. Email — Simplified RFC 5321 format check */
+ValidationResult ValidateEmail(std::string_view input);
+
+/* 7. US Passport — 1 letter + 8 digits */
+ValidationResult ValidateUSPassport(std::string_view input);
+
+/* 8. US Driver License — Basic format validation */
+ValidationResult ValidateUSDriverLicense(std::string_view input);
+
+/* 9. IPv4 — Octet range 0-255 */
+ValidationResult ValidateIPv4(std::string_view input);
+
+/* 10. Date of Birth — Calendar validity (MM/DD/YYYY) */
+ValidationResult ValidateDateOfBirth(std::string_view input);
+
+}  // namespace validators
+
+/* ------------------------------------------------------------------ */
+/*  Convenience: validate by identifier type name                       */
+/* ------------------------------------------------------------------ */
+
+ValidationResult ValidateDataIdentifier(std::string_view type_name,
+                                         std::string_view input);
+
+}  // namespace akeso::dlp

--- a/agent/src/detection/file_type_detector.cpp
+++ b/agent/src/detection/file_type_detector.cpp
@@ -1,0 +1,567 @@
+/*
+ * file_type_detector.cpp
+ * AkesoDLP Agent - File Type Detection
+ *
+ * Custom magic byte signature table for 50+ file types.
+ * No libmagic dependency. Handles compound formats like
+ * ZIP-based Office documents by inspecting internal structure.
+ */
+
+#include "akeso/detection/file_type_detector.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <unordered_map>
+
+namespace akeso::dlp {
+
+/* ================================================================== */
+/*  Construction                                                        */
+/* ================================================================== */
+
+FileTypeDetector::FileTypeDetector() {
+    InitSignatures();
+}
+
+/* ================================================================== */
+/*  Signature table                                                     */
+/* ================================================================== */
+
+void FileTypeDetector::InitSignatures() {
+    signatures_.clear();
+
+    /* Helper lambda */
+    auto add = [this](std::vector<uint8_t> magic, size_t offset,
+                      const char* name, const char* mime,
+                      const char* ext, FileCategory cat, int conf) {
+        signatures_.push_back({
+            std::move(magic), offset,
+            name, mime, ext, cat, conf
+        });
+    };
+
+    /* ---- Documents ---- */
+    add({0x25, 0x50, 0x44, 0x46}, 0,
+        "PDF", "application/pdf", ".pdf", FileCategory::Document, 95);
+
+    add({0x7B, 0x5C, 0x72, 0x74, 0x66}, 0,
+        "RTF", "application/rtf", ".rtf", FileCategory::Document, 95);
+
+    /* OLE2 Compound Document (doc/xls/ppt/msg) — differentiated later */
+    add({0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1}, 0,
+        "OLE2 Compound", "application/x-ole-storage", ".doc", FileCategory::Document, 80);
+
+    /* ---- ZIP-based (Office Open XML, ODF, JAR, APK) ---- */
+    /* Detected as ZIP first, then refined in CheckCompoundFormats */
+    add({0x50, 0x4B, 0x03, 0x04}, 0,
+        "ZIP", "application/zip", ".zip", FileCategory::Archive, 70);
+
+    /* ---- Images ---- */
+    add({0xFF, 0xD8, 0xFF}, 0,
+        "JPEG", "image/jpeg", ".jpg", FileCategory::Image, 95);
+
+    add({0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, 0,
+        "PNG", "image/png", ".png", FileCategory::Image, 95);
+
+    add({0x47, 0x49, 0x46, 0x38, 0x37, 0x61}, 0,
+        "GIF87a", "image/gif", ".gif", FileCategory::Image, 95);
+
+    add({0x47, 0x49, 0x46, 0x38, 0x39, 0x61}, 0,
+        "GIF89a", "image/gif", ".gif", FileCategory::Image, 95);
+
+    add({0x42, 0x4D}, 0,
+        "BMP", "image/bmp", ".bmp", FileCategory::Image, 85);
+
+    /* TIFF (little-endian) */
+    add({0x49, 0x49, 0x2A, 0x00}, 0,
+        "TIFF", "image/tiff", ".tiff", FileCategory::Image, 95);
+
+    /* TIFF (big-endian) */
+    add({0x4D, 0x4D, 0x00, 0x2A}, 0,
+        "TIFF", "image/tiff", ".tiff", FileCategory::Image, 95);
+
+    /* WebP */
+    add({0x52, 0x49, 0x46, 0x46}, 0,
+        "RIFF", "application/octet-stream", ".riff", FileCategory::Unknown, 60);
+    /* WebP is RIFF + "WEBP" at offset 8 — handled in CheckCompoundFormats */
+
+    /* ICO */
+    add({0x00, 0x00, 0x01, 0x00}, 0,
+        "ICO", "image/x-icon", ".ico", FileCategory::Image, 85);
+
+    /* PSD */
+    add({0x38, 0x42, 0x50, 0x53}, 0,
+        "PSD", "image/vnd.adobe.photoshop", ".psd", FileCategory::Image, 95);
+
+    /* ---- Audio ---- */
+    /* MP3 (ID3v2 tag) */
+    add({0x49, 0x44, 0x33}, 0,
+        "MP3", "audio/mpeg", ".mp3", FileCategory::Audio, 90);
+
+    /* MP3 (sync word, frame header) */
+    add({0xFF, 0xFB}, 0,
+        "MP3", "audio/mpeg", ".mp3", FileCategory::Audio, 75);
+
+    /* WAV (RIFF + WAVE) — handled in CheckCompoundFormats */
+
+    /* FLAC */
+    add({0x66, 0x4C, 0x61, 0x43}, 0,
+        "FLAC", "audio/flac", ".flac", FileCategory::Audio, 95);
+
+    /* OGG */
+    add({0x4F, 0x67, 0x67, 0x53}, 0,
+        "OGG", "audio/ogg", ".ogg", FileCategory::Audio, 90);
+
+    /* AAC (ADTS) */
+    add({0xFF, 0xF1}, 0,
+        "AAC", "audio/aac", ".aac", FileCategory::Audio, 75);
+
+    /* ---- Video ---- */
+    /* AVI (RIFF + AVI) — handled in CheckCompoundFormats */
+
+    /* MKV/WebM (Matroska) — refined in CheckCompoundFormats */
+    add({0x1A, 0x45, 0xDF, 0xA3}, 0,
+        "MKV", "video/x-matroska", ".mkv", FileCategory::Video, 85);
+
+    /* FLV */
+    add({0x46, 0x4C, 0x56, 0x01}, 0,
+        "FLV", "video/x-flv", ".flv", FileCategory::Video, 95);
+
+    /* MP4 (ftyp box) — check at offset 4 */
+    add({0x66, 0x74, 0x79, 0x70}, 4,
+        "MP4", "video/mp4", ".mp4", FileCategory::Video, 90);
+
+    /* ---- Archives ---- */
+    /* ZIP already added above */
+
+    /* RAR v5 */
+    add({0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x01, 0x00}, 0,
+        "RAR5", "application/x-rar-compressed", ".rar", FileCategory::Archive, 95);
+
+    /* RAR v4 */
+    add({0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00}, 0,
+        "RAR", "application/x-rar-compressed", ".rar", FileCategory::Archive, 95);
+
+    /* 7z */
+    add({0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C}, 0,
+        "7-Zip", "application/x-7z-compressed", ".7z", FileCategory::Archive, 95);
+
+    /* TAR (ustar at offset 257) */
+    add({0x75, 0x73, 0x74, 0x61, 0x72}, 257,
+        "TAR", "application/x-tar", ".tar", FileCategory::Archive, 90);
+
+    /* GZ */
+    add({0x1F, 0x8B}, 0,
+        "GZIP", "application/gzip", ".gz", FileCategory::Archive, 95);
+
+    /* BZ2 */
+    add({0x42, 0x5A, 0x68}, 0,
+        "BZ2", "application/x-bzip2", ".bz2", FileCategory::Archive, 95);
+
+    /* XZ */
+    add({0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00}, 0,
+        "XZ", "application/x-xz", ".xz", FileCategory::Archive, 95);
+
+    /* ZSTD */
+    add({0x28, 0xB5, 0x2F, 0xFD}, 0,
+        "ZSTD", "application/zstd", ".zst", FileCategory::Archive, 95);
+
+    /* ---- Executables ---- */
+    /* PE (MZ header) */
+    add({0x4D, 0x5A}, 0,
+        "PE Executable", "application/x-dosexec", ".exe", FileCategory::Executable, 90);
+
+    /* ELF */
+    add({0x7F, 0x45, 0x4C, 0x46}, 0,
+        "ELF", "application/x-elf", ".elf", FileCategory::Executable, 95);
+
+    /* Mach-O (32-bit) */
+    add({0xFE, 0xED, 0xFA, 0xCE}, 0,
+        "Mach-O 32", "application/x-mach-binary", ".macho", FileCategory::Executable, 95);
+
+    /* Mach-O (64-bit) */
+    add({0xFE, 0xED, 0xFA, 0xCF}, 0,
+        "Mach-O 64", "application/x-mach-binary", ".macho", FileCategory::Executable, 95);
+
+    /* Mach-O (reverse byte order 32) */
+    add({0xCE, 0xFA, 0xED, 0xFE}, 0,
+        "Mach-O 32 (LE)", "application/x-mach-binary", ".macho", FileCategory::Executable, 95);
+
+    /* Mach-O (reverse byte order 64) */
+    add({0xCF, 0xFA, 0xED, 0xFE}, 0,
+        "Mach-O 64 (LE)", "application/x-mach-binary", ".macho", FileCategory::Executable, 95);
+
+    /* Mach-O Universal (Fat) */
+    add({0xCA, 0xFE, 0xBA, 0xBE}, 0,
+        "Mach-O Universal", "application/x-mach-binary", ".macho", FileCategory::Executable, 85);
+
+    /* MSI (also OLE2, but has specific CLSID — handle in compound) */
+
+    /* ---- Scripts ---- */
+    /* Shebang */
+    add({0x23, 0x21}, 0,
+        "Script (Shebang)", "text/x-script", ".sh", FileCategory::Script, 70);
+
+    /* ---- Database ---- */
+    /* SQLite */
+    add({0x53, 0x51, 0x4C, 0x69, 0x74, 0x65, 0x20, 0x66,
+         0x6F, 0x72, 0x6D, 0x61, 0x74, 0x20, 0x33, 0x00}, 0,
+        "SQLite", "application/x-sqlite3", ".sqlite", FileCategory::Database, 95);
+
+    /* MS Access (JET) */
+    add({0x00, 0x01, 0x00, 0x00, 0x53, 0x74, 0x61, 0x6E,
+         0x64, 0x61, 0x72, 0x64, 0x20, 0x4A, 0x65, 0x74}, 0,
+        "MS Access", "application/x-msaccess", ".mdb", FileCategory::Database, 90);
+
+    /* ---- Fonts ---- */
+    /* TTF */
+    add({0x00, 0x01, 0x00, 0x00, 0x00}, 0,
+        "TrueType Font", "font/ttf", ".ttf", FileCategory::Font, 80);
+
+    /* OTF */
+    add({0x4F, 0x54, 0x54, 0x4F}, 0,
+        "OpenType Font", "font/otf", ".otf", FileCategory::Font, 95);
+
+    /* WOFF */
+    add({0x77, 0x4F, 0x46, 0x46}, 0,
+        "WOFF", "font/woff", ".woff", FileCategory::Font, 95);
+
+    /* WOFF2 */
+    add({0x77, 0x4F, 0x46, 0x32}, 0,
+        "WOFF2", "font/woff2", ".woff2", FileCategory::Font, 95);
+
+    /* ---- CAD ---- */
+    /* DWG */
+    add({0x41, 0x43, 0x31, 0x30}, 0,
+        "DWG", "image/vnd.dwg", ".dwg", FileCategory::CAD, 95);
+
+    /* ---- Email ---- */
+    /* EML typically starts with headers — detected by name */
+
+    /* ---- Additional formats ---- */
+
+    /* WASM (WebAssembly) */
+    add({0x00, 0x61, 0x73, 0x6D}, 0,
+        "WebAssembly", "application/wasm", ".wasm", FileCategory::Executable, 95);
+
+    /* LZ4 */
+    add({0x04, 0x22, 0x4D, 0x18}, 0,
+        "LZ4", "application/x-lz4", ".lz4", FileCategory::Archive, 95);
+
+    /* Java class file */
+    add({0xCA, 0xFE, 0xBA, 0xBE}, 0,
+        "Java Class", "application/java-vm", ".class", FileCategory::Executable, 80);
+
+    /* ISO 9660 CD image (offset 32769) */
+    add({0x43, 0x44, 0x30, 0x30, 0x31}, 32769,
+        "ISO 9660", "application/x-iso9660-image", ".iso", FileCategory::Archive, 90);
+
+    /* Windows shortcut (LNK) */
+    add({0x4C, 0x00, 0x00, 0x00, 0x01, 0x14, 0x02, 0x00}, 0,
+        "LNK", "application/x-ms-shortcut", ".lnk", FileCategory::Executable, 90);
+
+    /* PCX image */
+    add({0x0A, 0x05, 0x01, 0x08}, 0,
+        "PCX", "image/x-pcx", ".pcx", FileCategory::Image, 80);
+
+    /* MIDI */
+    add({0x4D, 0x54, 0x68, 0x64}, 0,
+        "MIDI", "audio/midi", ".mid", FileCategory::Audio, 95);
+
+    /* Sort by magic length descending for longest-match-first */
+    std::sort(signatures_.begin(), signatures_.end(),
+              [](const MagicSignature& a, const MagicSignature& b) {
+                  return a.magic.size() > b.magic.size();
+              });
+}
+
+/* ================================================================== */
+/*  Content-based detection                                             */
+/* ================================================================== */
+
+FileTypeResult FileTypeDetector::DetectFromContent(const uint8_t* data, size_t length) const {
+    if (!data || length == 0) {
+        return {"Unknown", "application/octet-stream", "", FileCategory::Unknown, 0};
+    }
+
+    FileTypeResult best{"Unknown", "application/octet-stream", "", FileCategory::Unknown, 0};
+
+    /* Check each signature */
+    for (const auto& sig : signatures_) {
+        if (sig.offset + sig.magic.size() > length) continue;
+
+        if (std::memcmp(data + sig.offset, sig.magic.data(), sig.magic.size()) == 0) {
+            if (sig.confidence > best.confidence) {
+                best.type_name  = sig.type_name;
+                best.mime_type  = sig.mime_type;
+                best.extension  = sig.extension;
+                best.category   = sig.category;
+                best.confidence = sig.confidence;
+            }
+        }
+    }
+
+    /* Refine compound formats (ZIP→Office, RIFF→WAV/AVI/WebP, etc.) */
+    auto compound = CheckCompoundFormats(data, length);
+    if (compound.confidence > best.confidence) {
+        best = compound;
+    }
+
+    return best;
+}
+
+FileTypeResult FileTypeDetector::DetectFromContent(const char* data, size_t length) const {
+    return DetectFromContent(reinterpret_cast<const uint8_t*>(data), length);
+}
+
+/* ================================================================== */
+/*  Compound format refinement                                          */
+/* ================================================================== */
+
+FileTypeResult FileTypeDetector::CheckCompoundFormats(const uint8_t* data, size_t length) const {
+    FileTypeResult result{"Unknown", "application/octet-stream", "", FileCategory::Unknown, 0};
+
+    /* ---- ZIP-based Office formats ---- */
+    if (length >= 4 && data[0] == 0x50 && data[1] == 0x4B &&
+        data[2] == 0x03 && data[3] == 0x04) {
+
+        /* Search for internal file names that identify the Office type.
+         * ZIP local file headers contain the filename; look for known
+         * paths within first 8KB of the file. */
+        std::string_view content(reinterpret_cast<const char*>(data),
+                                 std::min(length, static_cast<size_t>(8192)));
+
+        if (content.find("word/") != std::string_view::npos) {
+            return {"DOCX", "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    ".docx", FileCategory::Document, 95};
+        }
+        if (content.find("xl/") != std::string_view::npos) {
+            return {"XLSX", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    ".xlsx", FileCategory::Spreadsheet, 95};
+        }
+        if (content.find("ppt/") != std::string_view::npos) {
+            return {"PPTX", "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                    ".pptx", FileCategory::Presentation, 95};
+        }
+        if (content.find("META-INF/") != std::string_view::npos) {
+            if (content.find("classes.dex") != std::string_view::npos) {
+                return {"APK", "application/vnd.android.package-archive",
+                        ".apk", FileCategory::Archive, 90};
+            }
+            return {"JAR", "application/java-archive", ".jar", FileCategory::Archive, 85};
+        }
+        if (content.find("mimetype") != std::string_view::npos) {
+            /* ODF: check mimetype content */
+            if (content.find("application/vnd.oasis.opendocument.text") != std::string_view::npos) {
+                return {"ODT", "application/vnd.oasis.opendocument.text",
+                        ".odt", FileCategory::Document, 95};
+            }
+            if (content.find("application/vnd.oasis.opendocument.spreadsheet") != std::string_view::npos) {
+                return {"ODS", "application/vnd.oasis.opendocument.spreadsheet",
+                        ".ods", FileCategory::Spreadsheet, 95};
+            }
+            if (content.find("application/vnd.oasis.opendocument.presentation") != std::string_view::npos) {
+                return {"ODP", "application/vnd.oasis.opendocument.presentation",
+                        ".odp", FileCategory::Presentation, 95};
+            }
+        }
+        /* Remains as generic ZIP */
+    }
+
+    /* ---- RIFF-based formats ---- */
+    if (length >= 12 && data[0] == 0x52 && data[1] == 0x49 &&
+        data[2] == 0x46 && data[3] == 0x46) {
+
+        std::string_view fourcc(reinterpret_cast<const char*>(data + 8), 4);
+
+        if (fourcc == "WEBP") {
+            return {"WebP", "image/webp", ".webp", FileCategory::Image, 95};
+        }
+        if (fourcc == "WAVE") {
+            return {"WAV", "audio/wav", ".wav", FileCategory::Audio, 95};
+        }
+        if (fourcc == "AVI ") {
+            return {"AVI", "video/x-msvideo", ".avi", FileCategory::Video, 95};
+        }
+    }
+
+    /* ---- Matroska vs WebM ---- */
+    if (length >= 4 && data[0] == 0x1A && data[1] == 0x45 &&
+        data[2] == 0xDF && data[3] == 0xA3) {
+
+        /* Search for DocType in first 64 bytes */
+        std::string_view header(reinterpret_cast<const char*>(data),
+                                std::min(length, static_cast<size_t>(64)));
+        if (header.find("webm") != std::string_view::npos) {
+            return {"WebM", "video/webm", ".webm", FileCategory::Video, 95};
+        }
+        /* Default to MKV */
+        return {"MKV", "video/x-matroska", ".mkv", FileCategory::Video, 90};
+    }
+
+    return result;
+}
+
+/* ================================================================== */
+/*  Name-based detection                                                */
+/* ================================================================== */
+
+FileTypeResult FileTypeDetector::DetectFromName(std::string_view filename) const {
+    std::string ext = GetExtension(filename);
+    if (ext.empty()) {
+        return {"Unknown", "application/octet-stream", "", FileCategory::Unknown, 0};
+    }
+
+    /* Extension to type mapping */
+    static const std::unordered_map<std::string, FileTypeResult> ext_map = {
+        /* Documents */
+        {".pdf",   {"PDF",  "application/pdf", ".pdf", FileCategory::Document, 50}},
+        {".doc",   {"DOC",  "application/msword", ".doc", FileCategory::Document, 50}},
+        {".docx",  {"DOCX", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", ".docx", FileCategory::Document, 50}},
+        {".rtf",   {"RTF",  "application/rtf", ".rtf", FileCategory::Document, 50}},
+        {".txt",   {"Text", "text/plain", ".txt", FileCategory::Document, 40}},
+        {".odt",   {"ODT",  "application/vnd.oasis.opendocument.text", ".odt", FileCategory::Document, 50}},
+
+        /* Spreadsheets */
+        {".xls",   {"XLS",  "application/vnd.ms-excel", ".xls", FileCategory::Spreadsheet, 50}},
+        {".xlsx",  {"XLSX", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", ".xlsx", FileCategory::Spreadsheet, 50}},
+        {".csv",   {"CSV",  "text/csv", ".csv", FileCategory::Spreadsheet, 40}},
+        {".ods",   {"ODS",  "application/vnd.oasis.opendocument.spreadsheet", ".ods", FileCategory::Spreadsheet, 50}},
+
+        /* Presentations */
+        {".ppt",   {"PPT",  "application/vnd.ms-powerpoint", ".ppt", FileCategory::Presentation, 50}},
+        {".pptx",  {"PPTX", "application/vnd.openxmlformats-officedocument.presentationml.presentation", ".pptx", FileCategory::Presentation, 50}},
+        {".odp",   {"ODP",  "application/vnd.oasis.opendocument.presentation", ".odp", FileCategory::Presentation, 50}},
+
+        /* Images */
+        {".jpg",   {"JPEG", "image/jpeg", ".jpg", FileCategory::Image, 50}},
+        {".jpeg",  {"JPEG", "image/jpeg", ".jpeg", FileCategory::Image, 50}},
+        {".png",   {"PNG",  "image/png", ".png", FileCategory::Image, 50}},
+        {".gif",   {"GIF",  "image/gif", ".gif", FileCategory::Image, 50}},
+        {".bmp",   {"BMP",  "image/bmp", ".bmp", FileCategory::Image, 50}},
+        {".tiff",  {"TIFF", "image/tiff", ".tiff", FileCategory::Image, 50}},
+        {".tif",   {"TIFF", "image/tiff", ".tif", FileCategory::Image, 50}},
+        {".webp",  {"WebP", "image/webp", ".webp", FileCategory::Image, 50}},
+        {".ico",   {"ICO",  "image/x-icon", ".ico", FileCategory::Image, 50}},
+        {".svg",   {"SVG",  "image/svg+xml", ".svg", FileCategory::Image, 50}},
+        {".psd",   {"PSD",  "image/vnd.adobe.photoshop", ".psd", FileCategory::Image, 50}},
+
+        /* Audio */
+        {".mp3",   {"MP3",  "audio/mpeg", ".mp3", FileCategory::Audio, 50}},
+        {".wav",   {"WAV",  "audio/wav", ".wav", FileCategory::Audio, 50}},
+        {".flac",  {"FLAC", "audio/flac", ".flac", FileCategory::Audio, 50}},
+        {".ogg",   {"OGG",  "audio/ogg", ".ogg", FileCategory::Audio, 50}},
+        {".aac",   {"AAC",  "audio/aac", ".aac", FileCategory::Audio, 50}},
+        {".m4a",   {"M4A",  "audio/mp4", ".m4a", FileCategory::Audio, 50}},
+        {".wma",   {"WMA",  "audio/x-ms-wma", ".wma", FileCategory::Audio, 50}},
+
+        /* Video */
+        {".mp4",   {"MP4",  "video/mp4", ".mp4", FileCategory::Video, 50}},
+        {".avi",   {"AVI",  "video/x-msvideo", ".avi", FileCategory::Video, 50}},
+        {".mkv",   {"MKV",  "video/x-matroska", ".mkv", FileCategory::Video, 50}},
+        {".mov",   {"MOV",  "video/quicktime", ".mov", FileCategory::Video, 50}},
+        {".webm",  {"WebM", "video/webm", ".webm", FileCategory::Video, 50}},
+        {".flv",   {"FLV",  "video/x-flv", ".flv", FileCategory::Video, 50}},
+        {".wmv",   {"WMV",  "video/x-ms-wmv", ".wmv", FileCategory::Video, 50}},
+
+        /* Archives */
+        {".zip",   {"ZIP",  "application/zip", ".zip", FileCategory::Archive, 50}},
+        {".rar",   {"RAR",  "application/x-rar-compressed", ".rar", FileCategory::Archive, 50}},
+        {".7z",    {"7-Zip","application/x-7z-compressed", ".7z", FileCategory::Archive, 50}},
+        {".tar",   {"TAR",  "application/x-tar", ".tar", FileCategory::Archive, 50}},
+        {".gz",    {"GZIP", "application/gzip", ".gz", FileCategory::Archive, 50}},
+        {".bz2",   {"BZ2",  "application/x-bzip2", ".bz2", FileCategory::Archive, 50}},
+        {".xz",    {"XZ",   "application/x-xz", ".xz", FileCategory::Archive, 50}},
+        {".zst",   {"ZSTD", "application/zstd", ".zst", FileCategory::Archive, 50}},
+
+        /* Executables */
+        {".exe",   {"PE Executable", "application/x-dosexec", ".exe", FileCategory::Executable, 50}},
+        {".dll",   {"DLL",  "application/x-dosexec", ".dll", FileCategory::Executable, 50}},
+        {".sys",   {"SYS Driver", "application/x-dosexec", ".sys", FileCategory::Executable, 50}},
+        {".msi",   {"MSI",  "application/x-msi", ".msi", FileCategory::Executable, 50}},
+
+        /* Scripts */
+        {".py",    {"Python", "text/x-python", ".py", FileCategory::Script, 50}},
+        {".js",    {"JavaScript", "text/javascript", ".js", FileCategory::Script, 50}},
+        {".ps1",   {"PowerShell", "text/x-powershell", ".ps1", FileCategory::Script, 50}},
+        {".bat",   {"Batch", "text/x-batch", ".bat", FileCategory::Script, 50}},
+        {".cmd",   {"Batch", "text/x-batch", ".cmd", FileCategory::Script, 50}},
+        {".sh",    {"Shell", "text/x-shellscript", ".sh", FileCategory::Script, 50}},
+        {".vbs",   {"VBScript", "text/x-vbscript", ".vbs", FileCategory::Script, 50}},
+
+        /* Database */
+        {".sqlite",{"SQLite", "application/x-sqlite3", ".sqlite", FileCategory::Database, 50}},
+        {".db",    {"Database", "application/x-sqlite3", ".db", FileCategory::Database, 40}},
+        {".mdb",   {"MS Access", "application/x-msaccess", ".mdb", FileCategory::Database, 50}},
+
+        /* Fonts */
+        {".ttf",   {"TrueType Font", "font/ttf", ".ttf", FileCategory::Font, 50}},
+        {".otf",   {"OpenType Font", "font/otf", ".otf", FileCategory::Font, 50}},
+        {".woff",  {"WOFF", "font/woff", ".woff", FileCategory::Font, 50}},
+        {".woff2", {"WOFF2","font/woff2", ".woff2", FileCategory::Font, 50}},
+
+        /* CAD */
+        {".dwg",   {"DWG", "image/vnd.dwg", ".dwg", FileCategory::CAD, 50}},
+
+        /* Email */
+        {".eml",   {"EML", "message/rfc822", ".eml", FileCategory::Email, 50}},
+        {".msg",   {"MSG", "application/vnd.ms-outlook", ".msg", FileCategory::Email, 50}},
+    };
+
+    auto it = ext_map.find(ext);
+    if (it != ext_map.end()) {
+        return it->second;
+    }
+
+    return {"Unknown", "application/octet-stream", ext, FileCategory::Unknown, 0};
+}
+
+/* ================================================================== */
+/*  Combined detection                                                  */
+/* ================================================================== */
+
+FileTypeResult FileTypeDetector::Detect(const uint8_t* data, size_t length,
+                                         std::string_view filename) const {
+    auto content_result = DetectFromContent(data, length);
+    auto name_result = DetectFromName(filename);
+
+    /* Content-based wins if it has reasonable confidence */
+    if (content_result.confidence >= 70) {
+        /* Boost if name agrees */
+        if (name_result.type_name == content_result.type_name ||
+            name_result.category == content_result.category) {
+            content_result.confidence = std::min(100, content_result.confidence + 5);
+        }
+        return content_result;
+    }
+
+    /* If content is weak but name is known, use name but flag lower confidence */
+    if (name_result.confidence > 0 && name_result.category != FileCategory::Unknown) {
+        return name_result;
+    }
+
+    /* Return whatever we have */
+    return (content_result.confidence > 0) ? content_result : name_result;
+}
+
+/* ================================================================== */
+/*  Utilities                                                           */
+/* ================================================================== */
+
+std::string FileTypeDetector::ToLower(std::string_view s) {
+    std::string result(s);
+    std::transform(result.begin(), result.end(), result.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return result;
+}
+
+std::string FileTypeDetector::GetExtension(std::string_view filename) {
+    auto dot = filename.rfind('.');
+    if (dot == std::string_view::npos || dot == filename.size() - 1) {
+        return "";
+    }
+    return ToLower(filename.substr(dot));
+}
+
+}  // namespace akeso::dlp

--- a/agent/src/detection/validators.cpp
+++ b/agent/src/detection/validators.cpp
@@ -1,0 +1,444 @@
+/*
+ * validators.cpp
+ * AkesoDLP Agent - Data Identifier Validators
+ *
+ * Checksum and format validators to reduce false positives from
+ * regex/keyword matches. Each validator takes a raw match string
+ * and returns Valid, Invalid, or Inconclusive.
+ */
+
+#include "akeso/detection/validators.h"
+
+#include <algorithm>
+#include <cctype>
+#include <charconv>
+#include <string>
+
+namespace akeso::dlp {
+
+/* ================================================================== */
+/*  Helpers                                                             */
+/* ================================================================== */
+
+namespace {
+
+/* Strip non-digit characters (spaces, dashes, etc.) */
+std::string ExtractDigits(std::string_view input) {
+    std::string digits;
+    digits.reserve(input.size());
+    for (char c : input) {
+        if (c >= '0' && c <= '9') digits += c;
+    }
+    return digits;
+}
+
+/* Strip non-alphanumeric characters */
+std::string ExtractAlnum(std::string_view input) {
+    std::string result;
+    result.reserve(input.size());
+    for (char c : input) {
+        if (std::isalnum(static_cast<unsigned char>(c))) result += c;
+    }
+    return result;
+}
+
+/* Parse a substring as an integer, returns -1 on failure */
+int ParseInt(std::string_view s) {
+    int val = 0;
+    auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), val);
+    if (ec != std::errc{}) return -1;
+    return val;
+}
+
+bool IsAlpha(char c) {
+    return std::isalpha(static_cast<unsigned char>(c)) != 0;
+}
+
+bool IsDigit(char c) {
+    return c >= '0' && c <= '9';
+}
+
+bool IsLeapYear(int year) {
+    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+}
+
+int DaysInMonth(int month, int year) {
+    static constexpr int days[] = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    if (month < 1 || month > 12) return 0;
+    if (month == 2 && IsLeapYear(year)) return 29;
+    return days[month];
+}
+
+}  // anonymous namespace
+
+/* ================================================================== */
+/*  1. Credit Card — Luhn algorithm                                    */
+/* ================================================================== */
+
+namespace validators {
+
+ValidationResult ValidateCreditCard(std::string_view input) {
+    std::string digits = ExtractDigits(input);
+
+    /* Credit card numbers are 13-19 digits */
+    if (digits.size() < 13 || digits.size() > 19) {
+        return ValidationResult::Invalid;
+    }
+
+    /* Luhn algorithm */
+    int sum = 0;
+    bool double_digit = false;
+
+    for (int i = static_cast<int>(digits.size()) - 1; i >= 0; --i) {
+        int d = digits[i] - '0';
+        if (double_digit) {
+            d *= 2;
+            if (d > 9) d -= 9;
+        }
+        sum += d;
+        double_digit = !double_digit;
+    }
+
+    return (sum % 10 == 0) ? ValidationResult::Valid : ValidationResult::Invalid;
+}
+
+/* ================================================================== */
+/*  2. SSN — Area/group number validation                              */
+/* ================================================================== */
+
+ValidationResult ValidateSSN(std::string_view input) {
+    std::string digits = ExtractDigits(input);
+
+    if (digits.size() != 9) {
+        return ValidationResult::Invalid;
+    }
+
+    /* Area number (first 3 digits) */
+    int area = ParseInt(std::string_view(digits.data(), 3));
+    if (area < 0) return ValidationResult::Invalid;
+
+    /* Invalid area numbers: 000, 666, 900-999 */
+    if (area == 0 || area == 666 || area >= 900) {
+        return ValidationResult::Invalid;
+    }
+
+    /* Group number (middle 2 digits) must not be 00 */
+    int group = ParseInt(std::string_view(digits.data() + 3, 2));
+    if (group == 0) return ValidationResult::Invalid;
+
+    /* Serial number (last 4 digits) must not be 0000 */
+    int serial = ParseInt(std::string_view(digits.data() + 5, 4));
+    if (serial == 0) return ValidationResult::Invalid;
+
+    return ValidationResult::Valid;
+}
+
+/* ================================================================== */
+/*  3. IBAN — MOD-97 checksum (ISO 13616)                              */
+/* ================================================================== */
+
+ValidationResult ValidateIBAN(std::string_view input) {
+    std::string alnum = ExtractAlnum(input);
+
+    if (alnum.size() < 5 || alnum.size() > 34) {
+        return ValidationResult::Invalid;
+    }
+
+    /* First two chars must be letters (country code) */
+    if (!IsAlpha(alnum[0]) || !IsAlpha(alnum[1])) {
+        return ValidationResult::Invalid;
+    }
+
+    /* Next two chars must be digits (check digits) */
+    if (!IsDigit(alnum[2]) || !IsDigit(alnum[3])) {
+        return ValidationResult::Invalid;
+    }
+
+    /* Rearrange: move first 4 characters to the end */
+    std::string rearranged = alnum.substr(4) + alnum.substr(0, 4);
+
+    /* Convert letters to numbers: A=10, B=11, ..., Z=35 */
+    std::string numeric;
+    numeric.reserve(rearranged.size() * 2);
+    for (char c : rearranged) {
+        if (IsDigit(c)) {
+            numeric += c;
+        } else {
+            int val = std::toupper(static_cast<unsigned char>(c)) - 'A' + 10;
+            numeric += std::to_string(val);
+        }
+    }
+
+    /* Compute MOD-97 using piece-wise arithmetic to avoid big integers */
+    int remainder = 0;
+    for (char c : numeric) {
+        remainder = (remainder * 10 + (c - '0')) % 97;
+    }
+
+    return (remainder == 1) ? ValidationResult::Valid : ValidationResult::Invalid;
+}
+
+/* ================================================================== */
+/*  4. ABA Routing Number — 3-7-1 weighted checksum                    */
+/* ================================================================== */
+
+ValidationResult ValidateABA(std::string_view input) {
+    std::string digits = ExtractDigits(input);
+
+    if (digits.size() != 9) {
+        return ValidationResult::Invalid;
+    }
+
+    /* 3-7-1 weighted checksum */
+    const int weights[] = {3, 7, 1, 3, 7, 1, 3, 7, 1};
+    int sum = 0;
+    for (int i = 0; i < 9; ++i) {
+        sum += (digits[i] - '0') * weights[i];
+    }
+
+    return (sum % 10 == 0) ? ValidationResult::Valid : ValidationResult::Invalid;
+}
+
+/* ================================================================== */
+/*  5. US Phone — Format validation                                    */
+/* ================================================================== */
+
+ValidationResult ValidateUSPhone(std::string_view input) {
+    std::string digits = ExtractDigits(input);
+
+    /* Accept 10 or 11 digits (with leading 1) */
+    if (digits.size() == 11 && digits[0] == '1') {
+        digits = digits.substr(1);
+    }
+
+    if (digits.size() != 10) {
+        return ValidationResult::Invalid;
+    }
+
+    /* Area code cannot start with 0 or 1 */
+    if (digits[0] == '0' || digits[0] == '1') {
+        return ValidationResult::Invalid;
+    }
+
+    /* Exchange code (digits 3-5) cannot start with 0 or 1
+     * Note: relaxed — modern NANP allows exchange codes starting with 1 */
+    if (digits[3] == '0') {
+        return ValidationResult::Invalid;
+    }
+
+    return ValidationResult::Valid;
+}
+
+/* ================================================================== */
+/*  6. Email — Simplified RFC 5321 format                              */
+/* ================================================================== */
+
+ValidationResult ValidateEmail(std::string_view input) {
+    /* Trim whitespace */
+    size_t start = 0;
+    size_t end = input.size();
+    while (start < end && std::isspace(static_cast<unsigned char>(input[start]))) ++start;
+    while (end > start && std::isspace(static_cast<unsigned char>(input[end - 1]))) --end;
+    std::string_view trimmed = input.substr(start, end - start);
+
+    if (trimmed.empty()) return ValidationResult::Invalid;
+
+    /* Find @ */
+    auto at_pos = trimmed.find('@');
+    if (at_pos == std::string_view::npos || at_pos == 0 || at_pos == trimmed.size() - 1) {
+        return ValidationResult::Invalid;
+    }
+
+    /* Only one @ allowed */
+    if (trimmed.find('@', at_pos + 1) != std::string_view::npos) {
+        return ValidationResult::Invalid;
+    }
+
+    auto local = trimmed.substr(0, at_pos);
+    auto domain = trimmed.substr(at_pos + 1);
+
+    /* Local part: max 64 chars */
+    if (local.size() > 64) return ValidationResult::Invalid;
+
+    /* Domain must contain at least one dot */
+    if (domain.find('.') == std::string_view::npos) {
+        return ValidationResult::Invalid;
+    }
+
+    /* Domain cannot start or end with dot or hyphen */
+    if (domain.front() == '.' || domain.front() == '-' ||
+        domain.back() == '.' || domain.back() == '-') {
+        return ValidationResult::Invalid;
+    }
+
+    /* TLD must be at least 2 characters */
+    auto last_dot = domain.rfind('.');
+    if (last_dot == std::string_view::npos || domain.size() - last_dot - 1 < 2) {
+        return ValidationResult::Invalid;
+    }
+
+    return ValidationResult::Valid;
+}
+
+/* ================================================================== */
+/*  7. US Passport — 1 letter + 8 digits                               */
+/* ================================================================== */
+
+ValidationResult ValidateUSPassport(std::string_view input) {
+    /* Trim whitespace */
+    size_t start = 0;
+    size_t end = input.size();
+    while (start < end && std::isspace(static_cast<unsigned char>(input[start]))) ++start;
+    while (end > start && std::isspace(static_cast<unsigned char>(input[end - 1]))) --end;
+    std::string_view trimmed = input.substr(start, end - start);
+
+    if (trimmed.size() != 9) return ValidationResult::Invalid;
+
+    /* First character must be a letter */
+    if (!IsAlpha(trimmed[0])) return ValidationResult::Invalid;
+
+    /* Remaining 8 must be digits */
+    for (size_t i = 1; i < 9; ++i) {
+        if (!IsDigit(trimmed[i])) return ValidationResult::Invalid;
+    }
+
+    return ValidationResult::Valid;
+}
+
+/* ================================================================== */
+/*  8. US Driver License — Basic format validation                     */
+/* ================================================================== */
+
+ValidationResult ValidateUSDriverLicense(std::string_view input) {
+    /* Trim whitespace */
+    size_t start = 0;
+    size_t end = input.size();
+    while (start < end && std::isspace(static_cast<unsigned char>(input[start]))) ++start;
+    while (end > start && std::isspace(static_cast<unsigned char>(input[end - 1]))) --end;
+    std::string_view trimmed = input.substr(start, end - start);
+
+    /* Most US DLs: 1 letter + 7-12 digits, or all digits (7-13) */
+    if (trimmed.size() < 7 || trimmed.size() > 13) {
+        return ValidationResult::Invalid;
+    }
+
+    /* Check if first char is letter followed by digits */
+    if (IsAlpha(trimmed[0])) {
+        for (size_t i = 1; i < trimmed.size(); ++i) {
+            if (!IsDigit(trimmed[i])) return ValidationResult::Invalid;
+        }
+        return ValidationResult::Valid;
+    }
+
+    /* All digits format */
+    for (char c : trimmed) {
+        if (!IsDigit(c)) return ValidationResult::Invalid;
+    }
+
+    return ValidationResult::Valid;
+}
+
+/* ================================================================== */
+/*  9. IPv4 — Octet range 0-255                                        */
+/* ================================================================== */
+
+ValidationResult ValidateIPv4(std::string_view input) {
+    /* Trim whitespace */
+    size_t start = 0;
+    size_t end = input.size();
+    while (start < end && std::isspace(static_cast<unsigned char>(input[start]))) ++start;
+    while (end > start && std::isspace(static_cast<unsigned char>(input[end - 1]))) --end;
+    std::string_view trimmed = input.substr(start, end - start);
+
+    int octets = 0;
+    size_t pos = 0;
+
+    while (pos <= trimmed.size() && octets < 4) {
+        /* Find next dot or end */
+        size_t dot = trimmed.find('.', pos);
+        if (dot == std::string_view::npos) dot = trimmed.size();
+
+        auto part = trimmed.substr(pos, dot - pos);
+        if (part.empty() || part.size() > 3) return ValidationResult::Invalid;
+
+        /* No leading zeros (except "0" itself) */
+        if (part.size() > 1 && part[0] == '0') return ValidationResult::Invalid;
+
+        int val = ParseInt(part);
+        if (val < 0 || val > 255) return ValidationResult::Invalid;
+
+        ++octets;
+        pos = dot + 1;
+    }
+
+    if (octets != 4) return ValidationResult::Invalid;
+
+    /* Reject 0.0.0.0 and 255.255.255.255 as likely not PII */
+    if (trimmed == "0.0.0.0" || trimmed == "255.255.255.255") {
+        return ValidationResult::Invalid;
+    }
+
+    return ValidationResult::Valid;
+}
+
+/* ================================================================== */
+/*  10. Date of Birth — Calendar validity (MM/DD/YYYY)                 */
+/* ================================================================== */
+
+ValidationResult ValidateDateOfBirth(std::string_view input) {
+    /* Trim whitespace */
+    size_t start = 0;
+    size_t end = input.size();
+    while (start < end && std::isspace(static_cast<unsigned char>(input[start]))) ++start;
+    while (end > start && std::isspace(static_cast<unsigned char>(input[end - 1]))) --end;
+    std::string_view trimmed = input.substr(start, end - start);
+
+    /* Expected format: MM/DD/YYYY (10 chars) */
+    if (trimmed.size() != 10) return ValidationResult::Invalid;
+    if (trimmed[2] != '/' || trimmed[5] != '/') return ValidationResult::Invalid;
+
+    int month = ParseInt(trimmed.substr(0, 2));
+    int day = ParseInt(trimmed.substr(3, 2));
+    int year = ParseInt(trimmed.substr(6, 4));
+
+    if (month < 1 || month > 12) return ValidationResult::Invalid;
+    if (year < 1900 || year > 2025) return ValidationResult::Invalid;
+    if (day < 1 || day > DaysInMonth(month, year)) return ValidationResult::Invalid;
+
+    return ValidationResult::Valid;
+}
+
+}  // namespace validators
+
+/* ================================================================== */
+/*  Convenience dispatcher                                              */
+/* ================================================================== */
+
+ValidationResult ValidateDataIdentifier(std::string_view type_name,
+                                         std::string_view input) {
+    if (type_name == "US SSN"       || type_name == "SSN")
+        return validators::ValidateSSN(input);
+    if (type_name == "Visa CC"      || type_name == "MasterCard CC" ||
+        type_name == "Credit Card"  || type_name == "CC")
+        return validators::ValidateCreditCard(input);
+    if (type_name == "IBAN")
+        return validators::ValidateIBAN(input);
+    if (type_name == "ABA"          || type_name == "ABA Routing")
+        return validators::ValidateABA(input);
+    if (type_name == "US Phone"     || type_name == "Phone")
+        return validators::ValidateUSPhone(input);
+    if (type_name == "Email")
+        return validators::ValidateEmail(input);
+    if (type_name == "US Passport"  || type_name == "Passport")
+        return validators::ValidateUSPassport(input);
+    if (type_name == "US DL"        || type_name == "Driver License")
+        return validators::ValidateUSDriverLicense(input);
+    if (type_name == "IPv4")
+        return validators::ValidateIPv4(input);
+    if (type_name == "DOB"          || type_name == "Date of Birth")
+        return validators::ValidateDateOfBirth(input);
+
+    return ValidationResult::Inconclusive;
+}
+
+}  // namespace akeso::dlp

--- a/agent/tests/test_file_type_detector.cpp
+++ b/agent/tests/test_file_type_detector.cpp
@@ -1,0 +1,507 @@
+/*
+ * test_file_type_detector.cpp
+ * AkesoDLP Agent - File Type Detector Tests
+ *
+ * Tests: magic byte signatures, compound formats (ZIP→Office, RIFF→WAV/AVI/WebP),
+ *        renamed file detection, name-based fallback, combined detection.
+ */
+
+#include "akeso/detection/file_type_detector.h"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+using namespace akeso::dlp;
+
+/* ================================================================== */
+/*  Fixture                                                             */
+/* ================================================================== */
+
+class FileTypeDetectorTest : public ::testing::Test {
+protected:
+    FileTypeDetector detector_;
+
+    /* Helper: create a buffer with magic bytes */
+    std::vector<uint8_t> MakeBuffer(std::initializer_list<uint8_t> bytes,
+                                     size_t pad_to = 0) {
+        std::vector<uint8_t> buf(bytes);
+        if (pad_to > buf.size()) {
+            buf.resize(pad_to, 0);
+        }
+        return buf;
+    }
+
+    /* Helper: create a buffer with magic at an offset */
+    std::vector<uint8_t> MakeBufferAt(size_t offset,
+                                       std::initializer_list<uint8_t> bytes,
+                                       size_t total_size = 0) {
+        size_t needed = offset + bytes.size();
+        if (total_size < needed) total_size = needed;
+        std::vector<uint8_t> buf(total_size, 0);
+        size_t i = offset;
+        for (auto b : bytes) {
+            buf[i++] = b;
+        }
+        return buf;
+    }
+
+    /* Helper: create a fake ZIP with embedded path */
+    std::vector<uint8_t> MakeZipWith(const std::string& internal_path) {
+        /* Minimal ZIP local file header */
+        std::vector<uint8_t> buf = {0x50, 0x4B, 0x03, 0x04};
+        /* Pad with zeros for the rest of the local file header (26 bytes) */
+        buf.resize(30, 0);
+        /* Set filename length at offset 26 (little-endian) */
+        uint16_t name_len = static_cast<uint16_t>(internal_path.size());
+        buf[26] = static_cast<uint8_t>(name_len & 0xFF);
+        buf[27] = static_cast<uint8_t>((name_len >> 8) & 0xFF);
+        /* Append filename */
+        for (char c : internal_path) {
+            buf.push_back(static_cast<uint8_t>(c));
+        }
+        /* Pad to ensure enough data for compound format scanning */
+        buf.resize(std::max(buf.size(), static_cast<size_t>(256)), 0);
+        return buf;
+    }
+
+    /* Helper: create a RIFF buffer with a fourcc at offset 8 */
+    std::vector<uint8_t> MakeRiff(const char* fourcc) {
+        std::vector<uint8_t> buf = {
+            0x52, 0x49, 0x46, 0x46,  /* "RIFF" */
+            0x00, 0x00, 0x00, 0x00,  /* file size (dummy) */
+        };
+        for (int i = 0; i < 4; ++i) {
+            buf.push_back(static_cast<uint8_t>(fourcc[i]));
+        }
+        buf.resize(64, 0);
+        return buf;
+    }
+};
+
+/* ================================================================== */
+/*  Signature count                                                     */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, HasAtLeast50Signatures) {
+    EXPECT_GE(detector_.SignatureCount(), 50u);
+}
+
+/* ================================================================== */
+/*  Document formats                                                    */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, DetectPDF) {
+    auto buf = MakeBuffer({0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "PDF");
+    EXPECT_EQ(result.category, FileCategory::Document);
+    EXPECT_GE(result.confidence, 90);
+}
+
+TEST_F(FileTypeDetectorTest, DetectRTF) {
+    auto buf = MakeBuffer({0x7B, 0x5C, 0x72, 0x74, 0x66, 0x31});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "RTF");
+    EXPECT_EQ(result.category, FileCategory::Document);
+}
+
+TEST_F(FileTypeDetectorTest, DetectOLE2) {
+    auto buf = MakeBuffer({0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1}, 64);
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "OLE2 Compound");
+    EXPECT_EQ(result.category, FileCategory::Document);
+}
+
+/* ================================================================== */
+/*  ZIP-based Office formats (compound detection)                       */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, DetectDOCX) {
+    auto buf = MakeZipWith("word/document.xml");
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "DOCX");
+    EXPECT_EQ(result.category, FileCategory::Document);
+    EXPECT_GE(result.confidence, 90);
+}
+
+TEST_F(FileTypeDetectorTest, DetectXLSX) {
+    auto buf = MakeZipWith("xl/workbook.xml");
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "XLSX");
+    EXPECT_EQ(result.category, FileCategory::Spreadsheet);
+}
+
+TEST_F(FileTypeDetectorTest, DetectPPTX) {
+    auto buf = MakeZipWith("ppt/presentation.xml");
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "PPTX");
+    EXPECT_EQ(result.category, FileCategory::Presentation);
+}
+
+/* ================================================================== */
+/*  Images                                                              */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, DetectJPEG) {
+    auto buf = MakeBuffer({0xFF, 0xD8, 0xFF, 0xE0});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "JPEG");
+    EXPECT_EQ(result.category, FileCategory::Image);
+}
+
+TEST_F(FileTypeDetectorTest, DetectPNG) {
+    auto buf = MakeBuffer({0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "PNG");
+    EXPECT_EQ(result.category, FileCategory::Image);
+}
+
+TEST_F(FileTypeDetectorTest, DetectGIF89a) {
+    auto buf = MakeBuffer({0x47, 0x49, 0x46, 0x38, 0x39, 0x61});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "GIF89a");
+    EXPECT_EQ(result.category, FileCategory::Image);
+}
+
+TEST_F(FileTypeDetectorTest, DetectBMP) {
+    auto buf = MakeBuffer({0x42, 0x4D, 0x00, 0x00, 0x00, 0x00}, 64);
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "BMP");
+    EXPECT_EQ(result.category, FileCategory::Image);
+}
+
+TEST_F(FileTypeDetectorTest, DetectTIFF_LE) {
+    auto buf = MakeBuffer({0x49, 0x49, 0x2A, 0x00});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "TIFF");
+    EXPECT_EQ(result.category, FileCategory::Image);
+}
+
+TEST_F(FileTypeDetectorTest, DetectTIFF_BE) {
+    auto buf = MakeBuffer({0x4D, 0x4D, 0x00, 0x2A});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "TIFF");
+    EXPECT_EQ(result.category, FileCategory::Image);
+}
+
+TEST_F(FileTypeDetectorTest, DetectWebP) {
+    auto buf = MakeRiff("WEBP");
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "WebP");
+    EXPECT_EQ(result.category, FileCategory::Image);
+}
+
+TEST_F(FileTypeDetectorTest, DetectICO) {
+    auto buf = MakeBuffer({0x00, 0x00, 0x01, 0x00, 0x01, 0x00}, 64);
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "ICO");
+    EXPECT_EQ(result.category, FileCategory::Image);
+}
+
+TEST_F(FileTypeDetectorTest, DetectPSD) {
+    auto buf = MakeBuffer({0x38, 0x42, 0x50, 0x53});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "PSD");
+    EXPECT_EQ(result.category, FileCategory::Image);
+}
+
+/* ================================================================== */
+/*  Audio                                                               */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, DetectMP3_ID3) {
+    auto buf = MakeBuffer({0x49, 0x44, 0x33, 0x04});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "MP3");
+    EXPECT_EQ(result.category, FileCategory::Audio);
+}
+
+TEST_F(FileTypeDetectorTest, DetectWAV) {
+    auto buf = MakeRiff("WAVE");
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "WAV");
+    EXPECT_EQ(result.category, FileCategory::Audio);
+}
+
+TEST_F(FileTypeDetectorTest, DetectFLAC) {
+    auto buf = MakeBuffer({0x66, 0x4C, 0x61, 0x43});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "FLAC");
+    EXPECT_EQ(result.category, FileCategory::Audio);
+}
+
+TEST_F(FileTypeDetectorTest, DetectOGG) {
+    auto buf = MakeBuffer({0x4F, 0x67, 0x67, 0x53});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "OGG");
+    EXPECT_EQ(result.category, FileCategory::Audio);
+}
+
+/* ================================================================== */
+/*  Video                                                               */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, DetectAVI) {
+    auto buf = MakeRiff("AVI ");
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "AVI");
+    EXPECT_EQ(result.category, FileCategory::Video);
+}
+
+TEST_F(FileTypeDetectorTest, DetectMP4) {
+    auto buf = MakeBufferAt(4, {0x66, 0x74, 0x79, 0x70}, 64);
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "MP4");
+    EXPECT_EQ(result.category, FileCategory::Video);
+}
+
+TEST_F(FileTypeDetectorTest, DetectMKV) {
+    auto buf = MakeBuffer({0x1A, 0x45, 0xDF, 0xA3}, 64);
+    /* No "webm" in header, so should default to MKV */
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "MKV");
+    EXPECT_EQ(result.category, FileCategory::Video);
+}
+
+TEST_F(FileTypeDetectorTest, DetectFLV) {
+    auto buf = MakeBuffer({0x46, 0x4C, 0x56, 0x01});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "FLV");
+    EXPECT_EQ(result.category, FileCategory::Video);
+}
+
+/* ================================================================== */
+/*  Archives                                                            */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, DetectZIP) {
+    /* Plain ZIP without Office internals */
+    auto buf = MakeBuffer({0x50, 0x4B, 0x03, 0x04, 0x00, 0x00}, 64);
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "ZIP");
+    EXPECT_EQ(result.category, FileCategory::Archive);
+}
+
+TEST_F(FileTypeDetectorTest, DetectRAR5) {
+    auto buf = MakeBuffer({0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x01, 0x00});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "RAR5");
+    EXPECT_EQ(result.category, FileCategory::Archive);
+}
+
+TEST_F(FileTypeDetectorTest, Detect7Zip) {
+    auto buf = MakeBuffer({0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "7-Zip");
+    EXPECT_EQ(result.category, FileCategory::Archive);
+}
+
+TEST_F(FileTypeDetectorTest, DetectGZIP) {
+    auto buf = MakeBuffer({0x1F, 0x8B, 0x08});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "GZIP");
+    EXPECT_EQ(result.category, FileCategory::Archive);
+}
+
+TEST_F(FileTypeDetectorTest, DetectBZ2) {
+    auto buf = MakeBuffer({0x42, 0x5A, 0x68, 0x39});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "BZ2");
+    EXPECT_EQ(result.category, FileCategory::Archive);
+}
+
+TEST_F(FileTypeDetectorTest, DetectXZ) {
+    auto buf = MakeBuffer({0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "XZ");
+    EXPECT_EQ(result.category, FileCategory::Archive);
+}
+
+TEST_F(FileTypeDetectorTest, DetectZSTD) {
+    auto buf = MakeBuffer({0x28, 0xB5, 0x2F, 0xFD});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "ZSTD");
+    EXPECT_EQ(result.category, FileCategory::Archive);
+}
+
+/* ================================================================== */
+/*  Executables                                                         */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, DetectPE) {
+    auto buf = MakeBuffer({0x4D, 0x5A, 0x90, 0x00}, 64);
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "PE Executable");
+    EXPECT_EQ(result.category, FileCategory::Executable);
+}
+
+TEST_F(FileTypeDetectorTest, DetectELF) {
+    auto buf = MakeBuffer({0x7F, 0x45, 0x4C, 0x46, 0x02});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "ELF");
+    EXPECT_EQ(result.category, FileCategory::Executable);
+}
+
+TEST_F(FileTypeDetectorTest, DetectMachO64) {
+    auto buf = MakeBuffer({0xFE, 0xED, 0xFA, 0xCF});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "Mach-O 64");
+    EXPECT_EQ(result.category, FileCategory::Executable);
+}
+
+/* ================================================================== */
+/*  Database                                                            */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, DetectSQLite) {
+    /* "SQLite format 3\0" */
+    auto buf = MakeBuffer({0x53, 0x51, 0x4C, 0x69, 0x74, 0x65, 0x20, 0x66,
+                            0x6F, 0x72, 0x6D, 0x61, 0x74, 0x20, 0x33, 0x00});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "SQLite");
+    EXPECT_EQ(result.category, FileCategory::Database);
+}
+
+/* ================================================================== */
+/*  Scripts                                                             */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, DetectShebang) {
+    std::string script = "#!/usr/bin/env python3\nprint('hello')";
+    auto result = detector_.DetectFromContent(script.data(), script.size());
+    EXPECT_EQ(result.type_name, "Script (Shebang)");
+    EXPECT_EQ(result.category, FileCategory::Script);
+}
+
+/* ================================================================== */
+/*  Fonts                                                               */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, DetectOTF) {
+    auto buf = MakeBuffer({0x4F, 0x54, 0x54, 0x4F});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "OpenType Font");
+    EXPECT_EQ(result.category, FileCategory::Font);
+}
+
+TEST_F(FileTypeDetectorTest, DetectWOFF2) {
+    auto buf = MakeBuffer({0x77, 0x4F, 0x46, 0x32});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "WOFF2");
+    EXPECT_EQ(result.category, FileCategory::Font);
+}
+
+/* ================================================================== */
+/*  CAD                                                                 */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, DetectDWG) {
+    auto buf = MakeBuffer({0x41, 0x43, 0x31, 0x30, 0x31, 0x38});
+    auto result = detector_.DetectFromContent(buf.data(), buf.size());
+    EXPECT_EQ(result.type_name, "DWG");
+    EXPECT_EQ(result.category, FileCategory::CAD);
+}
+
+/* ================================================================== */
+/*  Acceptance: renamed file detection                                  */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, DocxRenamedToTxt_DetectedAsOffice) {
+    /* .docx renamed to .txt — content wins */
+    auto buf = MakeZipWith("word/document.xml");
+    auto result = detector_.Detect(buf.data(), buf.size(), "report.txt");
+    EXPECT_EQ(result.type_name, "DOCX");
+    EXPECT_EQ(result.category, FileCategory::Document);
+}
+
+TEST_F(FileTypeDetectorTest, ExeRenamedToJpg_DetectedAsPE) {
+    /* .exe renamed to .jpg — content wins */
+    auto buf = MakeBuffer({0x4D, 0x5A, 0x90, 0x00}, 64);
+    auto result = detector_.Detect(buf.data(), buf.size(), "photo.jpg");
+    EXPECT_EQ(result.type_name, "PE Executable");
+    EXPECT_EQ(result.category, FileCategory::Executable);
+}
+
+TEST_F(FileTypeDetectorTest, PdfRenamedToZip_DetectedAsPDF) {
+    auto buf = MakeBuffer({0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34});
+    auto result = detector_.Detect(buf.data(), buf.size(), "archive.zip");
+    EXPECT_EQ(result.type_name, "PDF");
+    EXPECT_EQ(result.category, FileCategory::Document);
+}
+
+/* ================================================================== */
+/*  Name-based detection                                                */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, NameBased_Python) {
+    auto result = detector_.DetectFromName("script.py");
+    EXPECT_EQ(result.type_name, "Python");
+    EXPECT_EQ(result.category, FileCategory::Script);
+}
+
+TEST_F(FileTypeDetectorTest, NameBased_PowerShell) {
+    auto result = detector_.DetectFromName("setup.ps1");
+    EXPECT_EQ(result.type_name, "PowerShell");
+    EXPECT_EQ(result.category, FileCategory::Script);
+}
+
+TEST_F(FileTypeDetectorTest, NameBased_CaseInsensitive) {
+    auto result = detector_.DetectFromName("DOCUMENT.PDF");
+    EXPECT_EQ(result.type_name, "PDF");
+}
+
+TEST_F(FileTypeDetectorTest, NameBased_UnknownExtension) {
+    auto result = detector_.DetectFromName("file.xyz");
+    EXPECT_EQ(result.category, FileCategory::Unknown);
+}
+
+/* ================================================================== */
+/*  Combined detection                                                  */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, CombinedBoostsConfidence) {
+    /* PDF content + .pdf name = boosted confidence */
+    auto buf = MakeBuffer({0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34});
+    auto result = detector_.Detect(buf.data(), buf.size(), "report.pdf");
+    EXPECT_EQ(result.type_name, "PDF");
+    EXPECT_EQ(result.confidence, 100);
+}
+
+TEST_F(FileTypeDetectorTest, CombinedFallsBackToName) {
+    /* Unknown content + known name */
+    std::vector<uint8_t> buf(64, 0x42);  /* Random bytes */
+    auto result = detector_.Detect(buf.data(), buf.size(), "script.ps1");
+    EXPECT_EQ(result.type_name, "PowerShell");
+    EXPECT_EQ(result.category, FileCategory::Script);
+}
+
+/* ================================================================== */
+/*  Edge cases                                                          */
+/* ================================================================== */
+
+TEST_F(FileTypeDetectorTest, NullBuffer) {
+    auto result = detector_.DetectFromContent(static_cast<const uint8_t*>(nullptr), 0);
+    EXPECT_EQ(result.category, FileCategory::Unknown);
+}
+
+TEST_F(FileTypeDetectorTest, EmptyBuffer) {
+    std::vector<uint8_t> empty;
+    auto result = detector_.DetectFromContent(empty.data(), 0);
+    EXPECT_EQ(result.category, FileCategory::Unknown);
+}
+
+TEST_F(FileTypeDetectorTest, TinyBuffer) {
+    /* 1 byte — not enough for most signatures */
+    uint8_t b = 0xFF;
+    auto result = detector_.DetectFromContent(&b, 1);
+    /* Might match nothing or a short sig, either way shouldn't crash */
+    EXPECT_GE(result.confidence, 0);
+}
+
+TEST_F(FileTypeDetectorTest, EmptyFilename) {
+    auto result = detector_.DetectFromName("");
+    EXPECT_EQ(result.category, FileCategory::Unknown);
+}

--- a/agent/tests/test_validators.cpp
+++ b/agent/tests/test_validators.cpp
@@ -1,0 +1,341 @@
+/*
+ * test_validators.cpp
+ * AkesoDLP Agent - Data Identifier Validator Tests
+ *
+ * Tests: Luhn (CC), SSN area validation, IBAN MOD-97, ABA checksum,
+ *        US Phone, Email, US Passport, US DL, IPv4, DOB.
+ */
+
+#include "akeso/detection/validators.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace akeso::dlp;
+using VR = ValidationResult;
+
+/* ================================================================== */
+/*  1. Credit Card — Luhn                                              */
+/* ================================================================== */
+
+TEST(ValidatorsTest, CC_ValidVisa) {
+    EXPECT_EQ(validators::ValidateCreditCard("4111111111111111"), VR::Valid);
+}
+
+TEST(ValidatorsTest, CC_ValidVisaWithDashes) {
+    EXPECT_EQ(validators::ValidateCreditCard("4111-1111-1111-1111"), VR::Valid);
+}
+
+TEST(ValidatorsTest, CC_ValidVisaWithSpaces) {
+    EXPECT_EQ(validators::ValidateCreditCard("4111 1111 1111 1111"), VR::Valid);
+}
+
+TEST(ValidatorsTest, CC_ValidMasterCard) {
+    EXPECT_EQ(validators::ValidateCreditCard("5500000000000004"), VR::Valid);
+}
+
+TEST(ValidatorsTest, CC_ValidAmex) {
+    EXPECT_EQ(validators::ValidateCreditCard("378282246310005"), VR::Valid);
+}
+
+TEST(ValidatorsTest, CC_InvalidLuhn) {
+    EXPECT_EQ(validators::ValidateCreditCard("4111111111111112"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, CC_TooShort) {
+    EXPECT_EQ(validators::ValidateCreditCard("411111"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, CC_TooLong) {
+    EXPECT_EQ(validators::ValidateCreditCard("41111111111111111111"), VR::Invalid);
+}
+
+/* ================================================================== */
+/*  2. SSN                                                              */
+/* ================================================================== */
+
+TEST(ValidatorsTest, SSN_Valid) {
+    EXPECT_EQ(validators::ValidateSSN("123-45-6789"), VR::Valid);
+}
+
+TEST(ValidatorsTest, SSN_ValidNoSeparator) {
+    EXPECT_EQ(validators::ValidateSSN("123456789"), VR::Valid);
+}
+
+TEST(ValidatorsTest, SSN_Area000_Rejected) {
+    EXPECT_EQ(validators::ValidateSSN("000-45-6789"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, SSN_Area666_Rejected) {
+    EXPECT_EQ(validators::ValidateSSN("666-45-6789"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, SSN_Area900Plus_Rejected) {
+    EXPECT_EQ(validators::ValidateSSN("900-45-6789"), VR::Invalid);
+    EXPECT_EQ(validators::ValidateSSN("999-45-6789"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, SSN_Group00_Rejected) {
+    EXPECT_EQ(validators::ValidateSSN("123-00-6789"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, SSN_Serial0000_Rejected) {
+    EXPECT_EQ(validators::ValidateSSN("123-45-0000"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, SSN_WrongLength) {
+    EXPECT_EQ(validators::ValidateSSN("1234-56-7890"), VR::Invalid);  /* 10 digits after strip */
+    EXPECT_EQ(validators::ValidateSSN("12345678"), VR::Invalid);      /* 8 digits */
+}
+
+/* ================================================================== */
+/*  3. IBAN — MOD-97                                                    */
+/* ================================================================== */
+
+TEST(ValidatorsTest, IBAN_ValidDE) {
+    EXPECT_EQ(validators::ValidateIBAN("DE89370400440532013000"), VR::Valid);
+}
+
+TEST(ValidatorsTest, IBAN_ValidGB) {
+    EXPECT_EQ(validators::ValidateIBAN("GB29NWBK60161331926819"), VR::Valid);
+}
+
+TEST(ValidatorsTest, IBAN_ValidWithSpaces) {
+    EXPECT_EQ(validators::ValidateIBAN("DE89 3704 0044 0532 0130 00"), VR::Valid);
+}
+
+TEST(ValidatorsTest, IBAN_InvalidChecksum) {
+    EXPECT_EQ(validators::ValidateIBAN("DE00370400440532013000"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, IBAN_TooShort) {
+    EXPECT_EQ(validators::ValidateIBAN("DE89"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, IBAN_NoCountryCode) {
+    EXPECT_EQ(validators::ValidateIBAN("12370400440532013000"), VR::Invalid);
+}
+
+/* ================================================================== */
+/*  4. ABA Routing — 3-7-1 checksum                                    */
+/* ================================================================== */
+
+TEST(ValidatorsTest, ABA_Valid) {
+    /* Bank of America: 026009593 */
+    EXPECT_EQ(validators::ValidateABA("026009593"), VR::Valid);
+}
+
+TEST(ValidatorsTest, ABA_ValidChase) {
+    /* JPMorgan Chase: 021000021 */
+    EXPECT_EQ(validators::ValidateABA("021000021"), VR::Valid);
+}
+
+TEST(ValidatorsTest, ABA_Invalid) {
+    EXPECT_EQ(validators::ValidateABA("123456789"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, ABA_WrongLength) {
+    EXPECT_EQ(validators::ValidateABA("12345"), VR::Invalid);
+}
+
+/* ================================================================== */
+/*  5. US Phone                                                         */
+/* ================================================================== */
+
+TEST(ValidatorsTest, Phone_ValidFormatted) {
+    EXPECT_EQ(validators::ValidateUSPhone("(555) 123-4567"), VR::Valid);
+}
+
+TEST(ValidatorsTest, Phone_ValidPlain) {
+    EXPECT_EQ(validators::ValidateUSPhone("5551234567"), VR::Valid);
+}
+
+TEST(ValidatorsTest, Phone_ValidWithCountryCode) {
+    EXPECT_EQ(validators::ValidateUSPhone("1-555-123-4567"), VR::Valid);
+}
+
+TEST(ValidatorsTest, Phone_AreaStartsWith0) {
+    EXPECT_EQ(validators::ValidateUSPhone("(055) 123-4567"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, Phone_AreaStartsWith1) {
+    EXPECT_EQ(validators::ValidateUSPhone("(155) 123-4567"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, Phone_ExchangeStartsWith0) {
+    EXPECT_EQ(validators::ValidateUSPhone("(555) 023-4567"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, Phone_ExchangeStartsWith1_Valid) {
+    /* Modern NANP allows exchange codes starting with 1 */
+    EXPECT_EQ(validators::ValidateUSPhone("(555) 123-4567"), VR::Valid);
+}
+
+/* ================================================================== */
+/*  6. Email                                                            */
+/* ================================================================== */
+
+TEST(ValidatorsTest, Email_Valid) {
+    EXPECT_EQ(validators::ValidateEmail("user@example.com"), VR::Valid);
+}
+
+TEST(ValidatorsTest, Email_ValidComplex) {
+    EXPECT_EQ(validators::ValidateEmail("user.name+tag@sub.domain.com"), VR::Valid);
+}
+
+TEST(ValidatorsTest, Email_NoAt) {
+    EXPECT_EQ(validators::ValidateEmail("userexample.com"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, Email_MultipleAt) {
+    EXPECT_EQ(validators::ValidateEmail("user@@example.com"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, Email_NoDomain) {
+    EXPECT_EQ(validators::ValidateEmail("user@"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, Email_NoDot) {
+    EXPECT_EQ(validators::ValidateEmail("user@examplecom"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, Email_ShortTLD) {
+    EXPECT_EQ(validators::ValidateEmail("user@example.c"), VR::Invalid);
+}
+
+/* ================================================================== */
+/*  7. US Passport                                                      */
+/* ================================================================== */
+
+TEST(ValidatorsTest, Passport_Valid) {
+    EXPECT_EQ(validators::ValidateUSPassport("C12345678"), VR::Valid);
+}
+
+TEST(ValidatorsTest, Passport_ValidLowerCase) {
+    /* Validator just checks format — letter + 8 digits */
+    EXPECT_EQ(validators::ValidateUSPassport("c12345678"), VR::Valid);
+}
+
+TEST(ValidatorsTest, Passport_NoLetter) {
+    EXPECT_EQ(validators::ValidateUSPassport("123456789"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, Passport_TooShort) {
+    EXPECT_EQ(validators::ValidateUSPassport("C1234567"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, Passport_TooLong) {
+    EXPECT_EQ(validators::ValidateUSPassport("C123456789"), VR::Invalid);
+}
+
+/* ================================================================== */
+/*  8. US Driver License                                                */
+/* ================================================================== */
+
+TEST(ValidatorsTest, DL_LetterPlusDigits) {
+    EXPECT_EQ(validators::ValidateUSDriverLicense("A1234567"), VR::Valid);
+}
+
+TEST(ValidatorsTest, DL_AllDigits) {
+    EXPECT_EQ(validators::ValidateUSDriverLicense("12345678"), VR::Valid);
+}
+
+TEST(ValidatorsTest, DL_TooShort) {
+    EXPECT_EQ(validators::ValidateUSDriverLicense("A123"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, DL_TooLong) {
+    EXPECT_EQ(validators::ValidateUSDriverLicense("A12345678901234"), VR::Invalid);
+}
+
+/* ================================================================== */
+/*  9. IPv4                                                             */
+/* ================================================================== */
+
+TEST(ValidatorsTest, IPv4_Valid) {
+    EXPECT_EQ(validators::ValidateIPv4("192.168.1.100"), VR::Valid);
+}
+
+TEST(ValidatorsTest, IPv4_ValidMin) {
+    EXPECT_EQ(validators::ValidateIPv4("1.0.0.1"), VR::Valid);
+}
+
+TEST(ValidatorsTest, IPv4_ValidMax) {
+    EXPECT_EQ(validators::ValidateIPv4("254.254.254.254"), VR::Valid);
+}
+
+TEST(ValidatorsTest, IPv4_OctetOver255) {
+    EXPECT_EQ(validators::ValidateIPv4("192.168.1.256"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, IPv4_LeadingZero) {
+    EXPECT_EQ(validators::ValidateIPv4("192.168.01.1"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, IPv4_AllZeros) {
+    EXPECT_EQ(validators::ValidateIPv4("0.0.0.0"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, IPv4_Broadcast) {
+    EXPECT_EQ(validators::ValidateIPv4("255.255.255.255"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, IPv4_TooFewOctets) {
+    EXPECT_EQ(validators::ValidateIPv4("192.168.1"), VR::Invalid);
+}
+
+/* ================================================================== */
+/*  10. Date of Birth                                                   */
+/* ================================================================== */
+
+TEST(ValidatorsTest, DOB_Valid) {
+    EXPECT_EQ(validators::ValidateDateOfBirth("01/15/1990"), VR::Valid);
+}
+
+TEST(ValidatorsTest, DOB_LeapDay) {
+    EXPECT_EQ(validators::ValidateDateOfBirth("02/29/2000"), VR::Valid);
+}
+
+TEST(ValidatorsTest, DOB_NotLeapDay) {
+    EXPECT_EQ(validators::ValidateDateOfBirth("02/29/2001"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, DOB_InvalidMonth) {
+    EXPECT_EQ(validators::ValidateDateOfBirth("13/01/1990"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, DOB_InvalidDay) {
+    EXPECT_EQ(validators::ValidateDateOfBirth("01/32/1990"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, DOB_YearTooOld) {
+    EXPECT_EQ(validators::ValidateDateOfBirth("01/15/1899"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, DOB_YearTooNew) {
+    EXPECT_EQ(validators::ValidateDateOfBirth("01/15/2030"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, DOB_WrongFormat) {
+    EXPECT_EQ(validators::ValidateDateOfBirth("1990-01-15"), VR::Invalid);
+}
+
+/* ================================================================== */
+/*  Convenience dispatcher                                              */
+/* ================================================================== */
+
+TEST(ValidatorsTest, Dispatcher_SSN) {
+    EXPECT_EQ(ValidateDataIdentifier("US SSN", "123-45-6789"), VR::Valid);
+    EXPECT_EQ(ValidateDataIdentifier("SSN", "000-45-6789"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, Dispatcher_CC) {
+    EXPECT_EQ(ValidateDataIdentifier("Visa CC", "4111111111111111"), VR::Valid);
+    EXPECT_EQ(ValidateDataIdentifier("MasterCard CC", "5500000000000004"), VR::Valid);
+    EXPECT_EQ(ValidateDataIdentifier("Credit Card", "4111111111111112"), VR::Invalid);
+}
+
+TEST(ValidatorsTest, Dispatcher_Unknown) {
+    EXPECT_EQ(ValidateDataIdentifier("UnknownType", "data"), VR::Inconclusive);
+}


### PR DESCRIPTION
## Summary
- **P4-T3: Data Identifier Validators** — 10 validators with checksum/format verification: Luhn (credit card), SSN area/group/serial rules, IBAN MOD-97, ABA routing 3-7-1 checksum, US phone (NANP), email (RFC 5321 simplified), US passport, US driver license, IPv4 octet range, DOB calendar validity. Convenience dispatcher by type name. 68 tests.
- **P4-T4: File Type Detector** — Custom magic byte signature table (52+ signatures, no libmagic). Covers documents, images, audio, video, archives, executables, scripts, databases, fonts, CAD. Compound format refinement (ZIP→DOCX/XLSX/PPTX, RIFF→WAV/AVI/WebP, Matroska→MKV/WebM). Content-based detection correctly identifies renamed files. 52 tests.
- Updated CMakeLists.txt with both new source files and test targets.

## Test plan
- [x] 68 validator tests pass (all 10 validators tested independently + dispatcher)
- [x] 52 file type detector tests pass (signatures, compound formats, renamed files, name-based, combined, edge cases)
- [x] All 7 test executables pass: ConfigTests, PolicyCacheTests, IncidentQueueTests, HsRegexAnalyzerTests, KeywordAnalyzerTests, ValidatorTests, FileTypeDetectorTests

🤖 Generated with [Claude Code](https://claude.com/claude-code)