### PR TITLE
Fix NetworkSettings blank page and improve login error messages

### DIFF
--- a/console/src/api/client.ts
+++ b/console/src/api/client.ts
@@ -75,7 +75,19 @@ async function request<T = unknown>(
     headers['Content-Type'] = 'application/json';
   }
 
-  const resp = await fetch(url, { ...init, headers, credentials: 'include' });
+  let resp: Response;
+  try {
+    resp = await fetch(url, { ...init, headers, credentials: 'include' });
+  } catch (err) {
+    // Network error — server unreachable, DNS failure, CORS, etc.
+    const isDown = err instanceof TypeError && /fetch|network/i.test(err.message);
+    throw new ApiError(
+      0,
+      isDown
+        ? `Cannot reach the API server at ${BASE_URL}. Is the server running? (uvicorn server.main:app --port 8000)`
+        : `Network error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 
   // Silent refresh on 401
   if (resp.status === 401 && accessToken) {

--- a/console/src/index.css
+++ b/console/src/index.css
@@ -18,6 +18,9 @@
   --color-surface-sidebar: #0f172a;   /* slate-900 */
   --color-surface-card: #1e293b;      /* slate-800 */
   --color-accent: #6366f1;            /* indigo-500 */
+  --color-accent-rgb: 99, 102, 241;   /* indigo-500 RGB */
+  --color-text-primary: #f8fafc;      /* slate-50 */
+  --color-text-secondary: #94a3b8;    /* slate-400 */
 }
 
 /* Light theme */
@@ -26,6 +29,9 @@
   --color-surface-sidebar: #ffffff;   /* white */
   --color-surface-card: #ffffff;      /* white */
   --color-accent: #4f46e5;            /* indigo-600 */
+  --color-accent-rgb: 79, 70, 229;    /* indigo-600 RGB */
+  --color-text-primary: #0f172a;      /* slate-900 */
+  --color-text-secondary: #64748b;    /* slate-500 */
 }
 
 * {

--- a/console/src/pages/Login.tsx
+++ b/console/src/pages/Login.tsx
@@ -48,7 +48,25 @@ export default function Login() {
         navigate('/');
       }
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Login failed';
+      let message = 'Login failed';
+      if (err && typeof err === 'object' && 'status' in err) {
+        const apiErr = err as { status: number; detail: string };
+        if (apiErr.status === 0) {
+          message = apiErr.detail; // Network/server down — already descriptive
+        } else if (apiErr.status === 401) {
+          message = 'Invalid username or password';
+        } else if (apiErr.status === 422) {
+          message = 'Please enter both username and password';
+        } else if (apiErr.status === 502 || apiErr.status === 503 || apiErr.status === 504) {
+          message = 'API server is not running. Start it with: uvicorn server.main:app --port 8000';
+        } else if (apiErr.status >= 500) {
+          message = `Server error (${apiErr.status}). Check the server logs.`;
+        } else {
+          message = apiErr.detail || `Request failed (${apiErr.status})`;
+        }
+      } else if (err instanceof Error) {
+        message = err.message;
+      }
       setError(message);
     } finally {
       setLoading(false);

--- a/console/src/pages/NetworkSettings.tsx
+++ b/console/src/pages/NetworkSettings.tsx
@@ -92,10 +92,28 @@ export default function NetworkSettings() {
   const [newDomain, setNewDomain] = useState('');
 
   useEffect(() => {
-    api.get<NetworkSettings>('/settings/network')
+    api.get<Record<string, unknown>>('/settings/network')
       .then((data) => {
-        setHttp(data.httpProxy);
-        setSmtp(data.smtpRelay);
+        // Server returns snake_case keys
+        const hp = (data.http_proxy ?? data.httpProxy) as Record<string, unknown> | undefined;
+        const sr = (data.smtp_relay ?? data.smtpRelay) as Record<string, unknown> | undefined;
+        if (hp) {
+          setHttp({
+            mode: (hp.mode as 'monitor' | 'prevent') ?? 'monitor',
+            blockThreshold: (hp.block_threshold ?? hp.blockThreshold ?? 1) as number,
+            domainAllowlist: (hp.domain_allowlist ?? hp.domainAllowlist ?? []) as string[],
+          });
+        }
+        if (sr) {
+          setSmtp({
+            mode: (sr.mode as 'monitor' | 'prevent') ?? 'monitor',
+            upstreamHost: (sr.upstream_host ?? sr.upstreamHost ?? 'mailhog') as string,
+            upstreamPort: (sr.upstream_port ?? sr.upstreamPort ?? 1025) as number,
+            blockThreshold: (sr.block_threshold ?? sr.blockThreshold ?? 5) as number,
+            modifyThreshold: (sr.modify_threshold ?? sr.modifyThreshold ?? 1) as number,
+            quarantineAddress: (sr.quarantine_address ?? sr.quarantineAddress ?? 'quarantine@dlp.local') as string,
+          });
+        }
       })
       .catch(() => {})
       .finally(() => setLoading(false));
@@ -111,7 +129,7 @@ export default function NetworkSettings() {
   async function handleSave() {
     setSaving(true);
     try {
-      const data = await api.put<NetworkSettings>('/settings/network', {
+      await api.put('/settings/network', {
         http_proxy: {
           mode: http.mode,
           block_threshold: http.blockThreshold,
@@ -126,8 +144,6 @@ export default function NetworkSettings() {
           quarantine_address: smtp.quarantineAddress,
         },
       });
-      setHttp(data.httpProxy);
-      setSmtp(data.smtpRelay);
       setToast({ type: 'success', message: 'Settings saved. Restart network services to apply.' });
     } catch {
       setToast({ type: 'error', message: 'Failed to save settings.' });


### PR DESCRIPTION
## Summary
- Add missing CSS variables (`--color-text-primary`, `--color-text-secondary`, `--color-accent-rgb`) that caused invisible text on the Network Settings page
- Fix snake_case/camelCase mismatch between API response and component state that crashed the page on render
- Add actionable error messages on login page for server-down (502/503/504) and network errors instead of generic "Request failed"

## Test plan
- [x] Network Settings page renders with both HTTP Proxy and SMTP Relay cards
- [x] Login shows "API server is not running..." when server is down
- [x] Login shows "Invalid username or password" on 401
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)