### PR TITLE
Add reporting, SIEM integration, smart response, and console pages (P8)

### DIFF
--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -11,6 +11,8 @@
  *   /identifiers — Data identifiers (protected)
  *   /users  — User management (protected)
  *   /settings/network — Network monitor settings (protected)
+ *   /reports — Report generation and export (protected)
+ *   /risk — User risk scores (protected)
  *   /fingerprints — Document fingerprint management (protected)
  */
 
@@ -28,6 +30,8 @@ import Login from './pages/Login';
 import MFAVerify from './pages/MFAVerify';
 import NetworkSettings from './pages/NetworkSettings';
 import Placeholder from './pages/Placeholder';
+import Reports from './pages/Reports';
+import UserRisk from './pages/UserRisk';
 import Policies from './pages/Policies';
 import PolicyEditor from './pages/PolicyEditor';
 
@@ -75,6 +79,8 @@ function App() {
           <Route path="detection" element={<Placeholder title="Detection" task="a future sprint" />} />
           <Route path="identifiers" element={<Placeholder title="Data Identifiers" task="a future sprint" />} />
           <Route path="users" element={<Placeholder title="Users" task="a future sprint" />} />
+          <Route path="reports" element={<Reports />} />
+          <Route path="risk" element={<UserRisk />} />
           <Route path="fingerprints" element={<Fingerprints />} />
           <Route path="settings/network" element={<NetworkSettings />} />
         </Route>

--- a/console/src/components/Layout.tsx
+++ b/console/src/components/Layout.tsx
@@ -21,6 +21,8 @@ import {
   Fingerprint,
   Globe,
   Settings,
+  FileBarChart,
+  AlertTriangle,
 } from 'lucide-react';
 import { useAuthStore } from '../stores/authStore';
 import { useThemeStore } from '../stores/themeStore';
@@ -34,6 +36,8 @@ const NAV_ITEMS = [
   { to: '/detection', icon: ScanSearch, label: 'Detection' },
   { to: '/identifiers', icon: BookOpen, label: 'Identifiers' },
   { to: '/users', icon: Users, label: 'Users' },
+  { to: '/reports', icon: FileBarChart, label: 'Reports' },
+  { to: '/risk', icon: AlertTriangle, label: 'User Risk' },
   { to: '/fingerprints', icon: Fingerprint, label: 'Fingerprints' },
   { to: '/settings/network', icon: Globe, label: 'Network' },
 ];

--- a/console/src/pages/IncidentSnapshot.tsx
+++ b/console/src/pages/IncidentSnapshot.tsx
@@ -6,7 +6,7 @@
 
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Send, Clock } from 'lucide-react';
+import { ArrowLeft, Send, Clock, Zap, ChevronDown, AlertTriangle, Mail, CheckCircle } from 'lucide-react';
 import useTitle from '../hooks/useTitle';
 import api from '../api/client';
 
@@ -84,6 +84,11 @@ export default function IncidentSnapshot() {
   const [newNote, setNewNote] = useState('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [responseOpen, setResponseOpen] = useState(false);
+  const [responseAction, setResponseAction] = useState<string | null>(null);
+  const [responseParams, setResponseParams] = useState<Record<string, string>>({});
+  const [responseLoading, setResponseLoading] = useState(false);
+  const [responseMsg, setResponseMsg] = useState<{ ok: boolean; text: string } | null>(null);
 
   useTitle(incident ? `Incident — ${incident.policy_name}` : 'Incident');
 
@@ -113,6 +118,40 @@ export default function IncidentSnapshot() {
     setIncident(updated);
     const h = await api.get<HistoryEntry[]>(`/incidents/${id}/history`);
     setHistory(h);
+  }
+
+  async function handleSmartResponse() {
+    if (!id || !responseAction) return;
+    setResponseLoading(true);
+    setResponseMsg(null);
+    try {
+      const result = await api.post<{ success: boolean; action: string; detail: string | null }>(
+        `/incidents/${id}/respond`,
+        { action: responseAction, params: responseParams },
+      );
+      setResponseMsg({ ok: result.success, text: result.detail || (result.success ? 'Done' : 'Failed') });
+      // Refresh incident, notes, and history after action
+      const [inc, n, h] = await Promise.all([
+        api.get<Incident>(`/incidents/${id}`),
+        api.get<Note[]>(`/incidents/${id}/notes`),
+        api.get<HistoryEntry[]>(`/incidents/${id}/history`),
+      ]);
+      setIncident(inc);
+      setNotes(n);
+      setHistory(h);
+      // Reset form after success
+      if (result.success) {
+        setTimeout(() => {
+          setResponseAction(null);
+          setResponseParams({});
+          setResponseMsg(null);
+        }, 2000);
+      }
+    } catch {
+      setResponseMsg({ ok: false, text: 'Failed to execute action' });
+    } finally {
+      setResponseLoading(false);
+    }
   }
 
   async function handleAddNote() {
@@ -179,6 +218,109 @@ export default function IncidentSnapshot() {
               <span style={{ fontSize: '0.75rem', color: '#64748b' }}>Matches</span>
               <p style={{ fontSize: '1.25rem', fontWeight: 600, color: SEVERITY_COLORS[incident.severity] || '#64748b' }}>{incident.match_count}</p>
             </div>
+          </div>
+
+          {/* Smart Response */}
+          <div style={cardStyle}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.75rem' }}>
+              <Zap style={{ width: '1rem', height: '1rem', color: '#eab308' }} />
+              <h2 style={{ fontSize: '0.875rem', fontWeight: 600, color: '#e2e8f0' }}>Smart Response</h2>
+            </div>
+
+            {/* Action selector */}
+            <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '0.75rem' }}>
+              {[
+                { key: 'add_note', label: 'Add Note', icon: Send },
+                { key: 'set_status', label: 'Set Status', icon: CheckCircle },
+                { key: 'send_email', label: 'Send Email', icon: Mail },
+                { key: 'escalate', label: 'Escalate', icon: AlertTriangle },
+              ].map(({ key, label, icon: Icon }) => (
+                <button
+                  key={key}
+                  onClick={() => { setResponseAction(responseAction === key ? null : key); setResponseParams({}); setResponseMsg(null); }}
+                  style={{
+                    padding: '0.375rem 0.75rem', borderRadius: '0.375rem', fontSize: '0.75rem', fontWeight: 500,
+                    display: 'flex', alignItems: 'center', gap: '0.375rem', cursor: 'pointer',
+                    border: responseAction === key ? '1px solid #6366f1' : '1px solid rgba(255,255,255,0.1)',
+                    backgroundColor: responseAction === key ? 'rgba(99,102,241,0.15)' : 'transparent',
+                    color: responseAction === key ? '#a5b4fc' : '#94a3b8',
+                  }}
+                >
+                  <Icon style={{ width: '0.75rem', height: '0.75rem' }} /> {label}
+                </button>
+              ))}
+            </div>
+
+            {/* Action params */}
+            {responseAction === 'add_note' && (
+              <input
+                type="text" placeholder="Note content..."
+                value={responseParams.content || ''}
+                onChange={(e) => setResponseParams({ content: e.target.value })}
+                style={{ width: '100%', padding: '0.375rem 0.75rem', borderRadius: '0.375rem', backgroundColor: 'var(--color-surface-page)', border: '1px solid rgba(255,255,255,0.1)', color: 'white', fontSize: '0.8125rem', outline: 'none', marginBottom: '0.5rem' }}
+              />
+            )}
+            {responseAction === 'set_status' && (
+              <select
+                value={responseParams.status || ''}
+                onChange={(e) => setResponseParams({ status: e.target.value })}
+                style={{ ...selectStyle, width: '100%', marginBottom: '0.5rem' }}
+              >
+                <option value="">Select status...</option>
+                <option value="new">New</option>
+                <option value="in_progress">In Progress</option>
+                <option value="resolved">Resolved</option>
+                <option value="dismissed">Dismissed</option>
+                <option value="escalated">Escalated</option>
+              </select>
+            )}
+            {responseAction === 'send_email' && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.375rem', marginBottom: '0.5rem' }}>
+                <input
+                  type="email" placeholder="Recipient email..."
+                  value={responseParams.recipient || ''}
+                  onChange={(e) => setResponseParams({ ...responseParams, recipient: e.target.value })}
+                  style={{ width: '100%', padding: '0.375rem 0.75rem', borderRadius: '0.375rem', backgroundColor: 'var(--color-surface-page)', border: '1px solid rgba(255,255,255,0.1)', color: 'white', fontSize: '0.8125rem', outline: 'none' }}
+                />
+                <input
+                  type="text" placeholder="Subject (optional)..."
+                  value={responseParams.subject || ''}
+                  onChange={(e) => setResponseParams({ ...responseParams, subject: e.target.value })}
+                  style={{ width: '100%', padding: '0.375rem 0.75rem', borderRadius: '0.375rem', backgroundColor: 'var(--color-surface-page)', border: '1px solid rgba(255,255,255,0.1)', color: 'white', fontSize: '0.8125rem', outline: 'none' }}
+                />
+              </div>
+            )}
+            {responseAction === 'escalate' && (
+              <input
+                type="text" placeholder="Escalation reason..."
+                value={responseParams.reason || ''}
+                onChange={(e) => setResponseParams({ reason: e.target.value })}
+                style={{ width: '100%', padding: '0.375rem 0.75rem', borderRadius: '0.375rem', backgroundColor: 'var(--color-surface-page)', border: '1px solid rgba(255,255,255,0.1)', color: 'white', fontSize: '0.8125rem', outline: 'none', marginBottom: '0.5rem' }}
+              />
+            )}
+
+            {/* Execute + result */}
+            {responseAction && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <button
+                  onClick={handleSmartResponse}
+                  disabled={responseLoading}
+                  style={{
+                    padding: '0.375rem 1rem', borderRadius: '0.375rem', fontSize: '0.8125rem', fontWeight: 500,
+                    backgroundColor: responseAction === 'escalate' ? '#dc2626' : '#6366f1',
+                    color: 'white', border: 'none', cursor: responseLoading ? 'not-allowed' : 'pointer',
+                    opacity: responseLoading ? 0.6 : 1,
+                  }}
+                >
+                  {responseLoading ? 'Running...' : 'Execute'}
+                </button>
+                {responseMsg && (
+                  <span style={{ fontSize: '0.75rem', color: responseMsg.ok ? '#4ade80' : '#f87171' }}>
+                    {responseMsg.text}
+                  </span>
+                )}
+              </div>
+            )}
           </div>
 
           {/* Matched content */}

--- a/console/src/pages/Reports.tsx
+++ b/console/src/pages/Reports.tsx
@@ -1,0 +1,375 @@
+/**
+ * Reports page (P8-T7).
+ * Generate summary/detail/trend reports with date filtering.
+ * Export as CSV download.
+ */
+
+import { useState } from 'react';
+import { FileText, Download, BarChart3, TrendingUp, List } from 'lucide-react';
+import useTitle from '../hooks/useTitle';
+import api, { getAccessToken } from '../api/client';
+
+interface Bucket {
+  key: string;
+  count: number;
+  percentage: number;
+}
+
+interface SummaryReport {
+  start_date: string;
+  end_date: string;
+  total_incidents: number;
+  by_severity: Bucket[];
+  by_policy: Bucket[];
+  by_channel: Bucket[];
+  by_status: Bucket[];
+  by_source_type: Bucket[];
+  top_users: Bucket[];
+}
+
+interface DetailIncident {
+  id: string;
+  policy_name: string;
+  severity: string;
+  status: string;
+  channel: string;
+  source_type: string;
+  user: string | null;
+  file_name: string | null;
+  action_taken: string;
+  match_count: number;
+  created_at: string;
+}
+
+interface DetailReport {
+  start_date: string;
+  end_date: string;
+  total_incidents: number;
+  incidents: DetailIncident[];
+}
+
+interface TrendDelta {
+  metric: string;
+  current_value: number;
+  previous_value: number;
+  delta: number;
+  delta_percent: number;
+}
+
+interface TrendReport {
+  current_period: SummaryReport;
+  previous_period: SummaryReport;
+  deltas: TrendDelta[];
+}
+
+const SEVERITY_COLORS: Record<string, string> = {
+  critical: '#ef4444', high: '#f97316', medium: '#eab308', low: '#3b82f6', info: '#64748b',
+};
+
+const cardStyle: React.CSSProperties = {
+  backgroundColor: 'var(--color-surface-card)', border: '1px solid rgba(255,255,255,0.08)',
+  borderRadius: '0.75rem', padding: '1.25rem',
+};
+
+const inputStyle: React.CSSProperties = {
+  padding: '0.375rem 0.75rem', borderRadius: '0.375rem', fontSize: '0.8125rem',
+  backgroundColor: 'var(--color-surface-page)', color: '#cbd5e1',
+  border: '1px solid rgba(255,255,255,0.1)', outline: 'none',
+};
+
+const btnStyle: React.CSSProperties = {
+  padding: '0.5rem 1rem', borderRadius: '0.375rem', fontSize: '0.8125rem', fontWeight: 500,
+  border: 'none', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '0.375rem',
+};
+
+function BucketTable({ title, buckets }: { title: string; buckets: Bucket[] }) {
+  if (!buckets.length) return null;
+  return (
+    <div>
+      <h3 style={{ fontSize: '0.8125rem', fontWeight: 600, color: '#94a3b8', marginBottom: '0.5rem' }}>{title}</h3>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.8125rem' }}>
+        <thead>
+          <tr style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+            <th style={{ textAlign: 'left', padding: '0.375rem 0', color: '#64748b', fontWeight: 500 }}>Category</th>
+            <th style={{ textAlign: 'right', padding: '0.375rem 0', color: '#64748b', fontWeight: 500 }}>Count</th>
+            <th style={{ textAlign: 'right', padding: '0.375rem 0', color: '#64748b', fontWeight: 500 }}>%</th>
+          </tr>
+        </thead>
+        <tbody>
+          {buckets.map((b) => (
+            <tr key={b.key} style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
+              <td style={{ padding: '0.375rem 0', color: '#e2e8f0' }}>{b.key}</td>
+              <td style={{ textAlign: 'right', padding: '0.375rem 0', color: '#e2e8f0' }}>{b.count}</td>
+              <td style={{ textAlign: 'right', padding: '0.375rem 0', color: '#94a3b8' }}>{b.percentage}%</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function Reports() {
+  useTitle('Reports');
+
+  const today = new Date().toISOString().slice(0, 10);
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10);
+
+  const [startDate, setStartDate] = useState(thirtyDaysAgo);
+  const [endDate, setEndDate] = useState(today);
+  const [tab, setTab] = useState<'summary' | 'detail' | 'trend'>('summary');
+  const [loading, setLoading] = useState(false);
+  const [summaryData, setSummaryData] = useState<SummaryReport | null>(null);
+  const [detailData, setDetailData] = useState<DetailReport | null>(null);
+  const [trendData, setTrendData] = useState<TrendReport | null>(null);
+  const [error, setError] = useState('');
+
+  async function generateReport() {
+    setLoading(true);
+    setError('');
+    try {
+      const body = {
+        start_date: new Date(startDate).toISOString(),
+        end_date: new Date(endDate + 'T23:59:59').toISOString(),
+      };
+
+      if (tab === 'summary') {
+        const data = await api.post<SummaryReport>('/reports/summary', body);
+        setSummaryData(data);
+      } else if (tab === 'detail') {
+        const data = await api.post<DetailReport>('/reports/detail', body);
+        setDetailData(data);
+      } else {
+        const data = await api.post<TrendReport>('/reports/trend', body);
+        setTrendData(data);
+      }
+    } catch {
+      setError('Failed to generate report. Is the server running?');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function downloadCSV() {
+    try {
+      const body = {
+        start_date: new Date(startDate).toISOString(),
+        end_date: new Date(endDate + 'T23:59:59').toISOString(),
+      };
+      const endpoint = tab === 'detail' ? '/reports/detail/csv' : '/reports/summary/csv';
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      const token = getAccessToken();
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+      const resp = await fetch(`/api${endpoint}`, {
+        method: 'POST',
+        headers,
+        credentials: 'include',
+        body: JSON.stringify(body),
+      });
+      const blob = await resp.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${tab}_report.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      setError('Failed to download CSV');
+    }
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '1.5rem' }}>
+        <FileText style={{ width: '1.25rem', height: '1.25rem', color: '#6366f1' }} />
+        <h1 style={{ fontSize: '1.25rem', fontWeight: 600, color: 'white' }}>Reports</h1>
+      </div>
+
+      {/* Controls */}
+      <div style={{ ...cardStyle, marginBottom: '1rem' }}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem', alignItems: 'flex-end' }}>
+          {/* Tab selector */}
+          <div style={{ display: 'flex', gap: '0.25rem', padding: '0.25rem', borderRadius: '0.5rem', backgroundColor: 'rgba(255,255,255,0.04)' }}>
+            {([
+              { key: 'summary', label: 'Summary', icon: BarChart3 },
+              { key: 'detail', label: 'Detail', icon: List },
+              { key: 'trend', label: 'Trend', icon: TrendingUp },
+            ] as const).map(({ key, label, icon: Icon }) => (
+              <button
+                key={key}
+                onClick={() => setTab(key)}
+                style={{
+                  ...btnStyle,
+                  backgroundColor: tab === key ? '#6366f1' : 'transparent',
+                  color: tab === key ? 'white' : '#94a3b8',
+                }}
+              >
+                <Icon style={{ width: '0.875rem', height: '0.875rem' }} /> {label}
+              </button>
+            ))}
+          </div>
+
+          {/* Date range */}
+          <div>
+            <label style={{ fontSize: '0.75rem', color: '#64748b', display: 'block', marginBottom: '0.25rem' }}>Start</label>
+            <input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} style={inputStyle} />
+          </div>
+          <div>
+            <label style={{ fontSize: '0.75rem', color: '#64748b', display: 'block', marginBottom: '0.25rem' }}>End</label>
+            <input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} style={inputStyle} />
+          </div>
+
+          {/* Generate */}
+          <button
+            onClick={generateReport}
+            disabled={loading}
+            style={{ ...btnStyle, backgroundColor: '#6366f1', color: 'white', opacity: loading ? 0.6 : 1 }}
+          >
+            {loading ? 'Generating...' : 'Generate'}
+          </button>
+
+          {/* CSV download (not for trend) */}
+          {tab !== 'trend' && (summaryData || detailData) && (
+            <button onClick={downloadCSV} style={{ ...btnStyle, backgroundColor: 'rgba(255,255,255,0.06)', color: '#94a3b8', border: '1px solid rgba(255,255,255,0.1)' }}>
+              <Download style={{ width: '0.875rem', height: '0.875rem' }} /> CSV
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div style={{ padding: '0.75rem 1rem', borderRadius: '0.5rem', backgroundColor: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.2)', color: '#fca5a5', fontSize: '0.8125rem', marginBottom: '1rem' }}>
+          {error}
+        </div>
+      )}
+
+      {/* Summary Report */}
+      {tab === 'summary' && summaryData && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          <div style={cardStyle}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+              <h2 style={{ fontSize: '1rem', fontWeight: 600, color: '#e2e8f0' }}>Summary</h2>
+              <span style={{ fontSize: '2rem', fontWeight: 700, color: '#6366f1' }}>{summaryData.total_incidents}</span>
+            </div>
+            <p style={{ fontSize: '0.8125rem', color: '#64748b' }}>
+              {new Date(summaryData.start_date).toLocaleDateString()} — {new Date(summaryData.end_date).toLocaleDateString()}
+            </p>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '1rem' }}>
+            {[
+              { title: 'By Severity', data: summaryData.by_severity },
+              { title: 'By Policy', data: summaryData.by_policy },
+              { title: 'By Channel', data: summaryData.by_channel },
+              { title: 'By Status', data: summaryData.by_status },
+              { title: 'By Source Type', data: summaryData.by_source_type },
+              { title: 'Top Users', data: summaryData.top_users },
+            ].map(({ title, data }) => (
+              <div key={title} style={cardStyle}>
+                <BucketTable title={title} buckets={data} />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Detail Report */}
+      {tab === 'detail' && detailData && (
+        <div style={cardStyle}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '1rem' }}>
+            <h2 style={{ fontSize: '1rem', fontWeight: 600, color: '#e2e8f0' }}>
+              Incidents ({detailData.total_incidents})
+            </h2>
+          </div>
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.8125rem' }}>
+              <thead>
+                <tr style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+                  {['Policy', 'Severity', 'Status', 'Channel', 'User', 'Action', 'Matches', 'Date'].map((h) => (
+                    <th key={h} style={{ textAlign: 'left', padding: '0.5rem', color: '#64748b', fontWeight: 500, whiteSpace: 'nowrap' }}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {detailData.incidents.map((inc) => (
+                  <tr key={inc.id} style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
+                    <td style={{ padding: '0.5rem', color: '#e2e8f0' }}>{inc.policy_name}</td>
+                    <td style={{ padding: '0.5rem' }}>
+                      <span style={{ color: SEVERITY_COLORS[inc.severity] || '#64748b', fontWeight: 500 }}>{inc.severity}</span>
+                    </td>
+                    <td style={{ padding: '0.5rem', color: '#94a3b8' }}>{inc.status}</td>
+                    <td style={{ padding: '0.5rem', color: '#94a3b8' }}>{inc.channel}</td>
+                    <td style={{ padding: '0.5rem', color: '#94a3b8' }}>{inc.user || '—'}</td>
+                    <td style={{ padding: '0.5rem', color: '#94a3b8' }}>{inc.action_taken}</td>
+                    <td style={{ padding: '0.5rem', color: '#94a3b8', textAlign: 'center' }}>{inc.match_count}</td>
+                    <td style={{ padding: '0.5rem', color: '#64748b', whiteSpace: 'nowrap' }}>{new Date(inc.created_at).toLocaleDateString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Trend Report */}
+      {tab === 'trend' && trendData && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          <div style={cardStyle}>
+            <h2 style={{ fontSize: '1rem', fontWeight: 600, color: '#e2e8f0', marginBottom: '1rem' }}>Trend Comparison</h2>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.8125rem' }}>
+              <thead>
+                <tr style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+                  {['Metric', 'Current', 'Previous', 'Delta', 'Change'].map((h) => (
+                    <th key={h} style={{ textAlign: h === 'Metric' ? 'left' : 'right', padding: '0.5rem', color: '#64748b', fontWeight: 500 }}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {trendData.deltas.map((d) => (
+                  <tr key={d.metric} style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
+                    <td style={{ padding: '0.5rem', color: '#e2e8f0', textTransform: 'capitalize' }}>
+                      {d.metric.replace(/_/g, ' ')}
+                    </td>
+                    <td style={{ textAlign: 'right', padding: '0.5rem', color: '#e2e8f0', fontWeight: 600 }}>{d.current_value}</td>
+                    <td style={{ textAlign: 'right', padding: '0.5rem', color: '#94a3b8' }}>{d.previous_value}</td>
+                    <td style={{ textAlign: 'right', padding: '0.5rem', color: d.delta > 0 ? '#f87171' : d.delta < 0 ? '#4ade80' : '#64748b', fontWeight: 500 }}>
+                      {d.delta > 0 ? '+' : ''}{d.delta}
+                    </td>
+                    <td style={{ textAlign: 'right', padding: '0.5rem', color: d.delta_percent > 0 ? '#f87171' : d.delta_percent < 0 ? '#4ade80' : '#64748b' }}>
+                      {d.delta_percent > 0 ? '+' : ''}{d.delta_percent}%
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Side-by-side period summaries */}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
+            <div style={cardStyle}>
+              <h3 style={{ fontSize: '0.875rem', fontWeight: 600, color: '#e2e8f0', marginBottom: '0.75rem' }}>
+                Current Period ({trendData.current_period.total_incidents} incidents)
+              </h3>
+              <BucketTable title="By Severity" buckets={trendData.current_period.by_severity} />
+            </div>
+            <div style={cardStyle}>
+              <h3 style={{ fontSize: '0.875rem', fontWeight: 600, color: '#e2e8f0', marginBottom: '0.75rem' }}>
+                Previous Period ({trendData.previous_period.total_incidents} incidents)
+              </h3>
+              <BucketTable title="By Severity" buckets={trendData.previous_period.by_severity} />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && !summaryData && !detailData && !trendData && !error && (
+        <div style={{ ...cardStyle, textAlign: 'center', padding: '3rem' }}>
+          <BarChart3 style={{ width: '2rem', height: '2rem', color: '#475569', margin: '0 auto 0.75rem' }} />
+          <p style={{ color: '#64748b', fontSize: '0.875rem' }}>
+            Select a report type and date range, then click Generate.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/console/src/pages/UserRisk.tsx
+++ b/console/src/pages/UserRisk.tsx
@@ -1,0 +1,213 @@
+/**
+ * User Risk page (P8-T7).
+ * Displays user risk scores sorted by normalized score descending.
+ * Color-coded risk levels with severity breakdown.
+ */
+
+import { useEffect, useState } from 'react';
+import { ShieldAlert, RefreshCw, User } from 'lucide-react';
+import useTitle from '../hooks/useTitle';
+import api from '../api/client';
+
+interface UserScore {
+  user: string;
+  raw_score: number;
+  normalized_score: number;
+  risk_level: string;
+  incident_count: number;
+  severity_breakdown: Record<string, number>;
+  latest_incident: string | null;
+  oldest_incident: string | null;
+}
+
+interface RiskResponse {
+  generated_at: string;
+  lookback_days: number;
+  users: UserScore[];
+}
+
+const RISK_COLORS: Record<string, string> = {
+  critical: '#ef4444',
+  high: '#f97316',
+  medium: '#eab308',
+  low: '#3b82f6',
+  minimal: '#64748b',
+};
+
+const RISK_BG: Record<string, string> = {
+  critical: 'rgba(239,68,68,0.12)',
+  high: 'rgba(249,115,22,0.12)',
+  medium: 'rgba(234,179,8,0.12)',
+  low: 'rgba(59,130,246,0.12)',
+  minimal: 'rgba(100,116,139,0.12)',
+};
+
+const cardStyle: React.CSSProperties = {
+  backgroundColor: 'var(--color-surface-card)', border: '1px solid rgba(255,255,255,0.08)',
+  borderRadius: '0.75rem', padding: '1.25rem',
+};
+
+export default function UserRisk() {
+  useTitle('User Risk');
+
+  const [data, setData] = useState<RiskResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [days, setDays] = useState(90);
+  const [error, setError] = useState('');
+
+  async function fetchRisk(lookback: number) {
+    setLoading(true);
+    setError('');
+    try {
+      const result = await api.get<RiskResponse>(`/reports/risk?days=${lookback}`);
+      setData(result);
+    } catch {
+      setError('Failed to load risk scores. Is the server running?');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { fetchRisk(days); }, [days]);
+
+  return (
+    <div>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1.5rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <ShieldAlert style={{ width: '1.25rem', height: '1.25rem', color: '#f97316' }} />
+          <h1 style={{ fontSize: '1.25rem', fontWeight: 600, color: 'white' }}>User Risk Scores</h1>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <label style={{ fontSize: '0.8125rem', color: '#64748b' }}>Lookback:</label>
+          <select
+            value={days}
+            onChange={(e) => setDays(Number(e.target.value))}
+            style={{
+              padding: '0.375rem 0.5rem', borderRadius: '0.375rem', fontSize: '0.8125rem',
+              backgroundColor: 'var(--color-surface-page)', color: '#cbd5e1',
+              border: '1px solid rgba(255,255,255,0.1)', outline: 'none',
+            }}
+          >
+            <option value={30}>30 days</option>
+            <option value={60}>60 days</option>
+            <option value={90}>90 days</option>
+            <option value={180}>180 days</option>
+            <option value={365}>1 year</option>
+          </select>
+          <button
+            onClick={() => fetchRisk(days)}
+            disabled={loading}
+            style={{
+              padding: '0.375rem 0.75rem', borderRadius: '0.375rem', fontSize: '0.8125rem',
+              backgroundColor: 'rgba(255,255,255,0.06)', color: '#94a3b8',
+              border: '1px solid rgba(255,255,255,0.1)', cursor: 'pointer',
+              display: 'flex', alignItems: 'center', gap: '0.25rem',
+            }}
+          >
+            <RefreshCw style={{ width: '0.75rem', height: '0.75rem' }} /> Refresh
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div style={{ padding: '0.75rem 1rem', borderRadius: '0.5rem', backgroundColor: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.2)', color: '#fca5a5', fontSize: '0.8125rem', marginBottom: '1rem' }}>
+          {error}
+        </div>
+      )}
+
+      {loading && (
+        <div style={{ textAlign: 'center', padding: '3rem', color: '#64748b' }}>Loading...</div>
+      )}
+
+      {!loading && data && data.users.length === 0 && (
+        <div style={{ ...cardStyle, textAlign: 'center', padding: '3rem' }}>
+          <User style={{ width: '2rem', height: '2rem', color: '#475569', margin: '0 auto 0.75rem' }} />
+          <p style={{ color: '#64748b', fontSize: '0.875rem' }}>
+            No user risk data for the selected period.
+          </p>
+        </div>
+      )}
+
+      {!loading && data && data.users.length > 0 && (
+        <div style={cardStyle}>
+          {data.generated_at && (
+            <p style={{ fontSize: '0.75rem', color: '#475569', marginBottom: '1rem' }}>
+              Generated: {new Date(data.generated_at).toLocaleString()} | Lookback: {data.lookback_days} days | Users: {data.users.length}
+            </p>
+          )}
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.8125rem' }}>
+            <thead>
+              <tr style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+                <th style={{ textAlign: 'left', padding: '0.5rem', color: '#64748b', fontWeight: 500 }}>User</th>
+                <th style={{ textAlign: 'center', padding: '0.5rem', color: '#64748b', fontWeight: 500 }}>Risk Score</th>
+                <th style={{ textAlign: 'center', padding: '0.5rem', color: '#64748b', fontWeight: 500 }}>Level</th>
+                <th style={{ textAlign: 'center', padding: '0.5rem', color: '#64748b', fontWeight: 500 }}>Incidents</th>
+                <th style={{ textAlign: 'left', padding: '0.5rem', color: '#64748b', fontWeight: 500 }}>Severity Breakdown</th>
+                <th style={{ textAlign: 'left', padding: '0.5rem', color: '#64748b', fontWeight: 500 }}>Latest</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.users.map((u) => (
+                <tr key={u.user} style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
+                  <td style={{ padding: '0.5rem', color: '#e2e8f0', fontWeight: 500 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                      <div style={{
+                        width: '1.5rem', height: '1.5rem', borderRadius: '50%',
+                        backgroundColor: RISK_BG[u.risk_level] || RISK_BG.minimal,
+                        display: 'flex', alignItems: 'center', justifyContent: 'center',
+                        fontSize: '0.625rem', fontWeight: 700, color: RISK_COLORS[u.risk_level] || RISK_COLORS.minimal,
+                      }}>
+                        {u.user.charAt(0).toUpperCase()}
+                      </div>
+                      {u.user}
+                    </div>
+                  </td>
+                  <td style={{ textAlign: 'center', padding: '0.5rem' }}>
+                    {/* Score bar */}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', justifyContent: 'center' }}>
+                      <div style={{ width: '4rem', height: '0.375rem', borderRadius: '0.25rem', backgroundColor: 'rgba(255,255,255,0.06)', overflow: 'hidden' }}>
+                        <div style={{
+                          width: `${u.normalized_score}%`,
+                          height: '100%', borderRadius: '0.25rem',
+                          backgroundColor: RISK_COLORS[u.risk_level] || RISK_COLORS.minimal,
+                        }} />
+                      </div>
+                      <span style={{ color: '#e2e8f0', fontWeight: 600, fontSize: '0.8125rem' }}>{u.normalized_score}</span>
+                    </div>
+                  </td>
+                  <td style={{ textAlign: 'center', padding: '0.5rem' }}>
+                    <span style={{
+                      padding: '0.125rem 0.5rem', borderRadius: '9999px', fontSize: '0.6875rem', fontWeight: 600,
+                      backgroundColor: RISK_BG[u.risk_level] || RISK_BG.minimal,
+                      color: RISK_COLORS[u.risk_level] || RISK_COLORS.minimal,
+                      textTransform: 'capitalize',
+                    }}>
+                      {u.risk_level}
+                    </span>
+                  </td>
+                  <td style={{ textAlign: 'center', padding: '0.5rem', color: '#94a3b8' }}>{u.incident_count}</td>
+                  <td style={{ padding: '0.5rem' }}>
+                    <div style={{ display: 'flex', gap: '0.375rem', flexWrap: 'wrap' }}>
+                      {Object.entries(u.severity_breakdown).map(([sev, count]) => (
+                        <span key={sev} style={{
+                          fontSize: '0.6875rem', padding: '0.125rem 0.375rem', borderRadius: '0.25rem',
+                          backgroundColor: 'rgba(255,255,255,0.04)', color: RISK_COLORS[sev] || '#94a3b8',
+                        }}>
+                          {sev}: {count}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                  <td style={{ padding: '0.5rem', color: '#64748b', whiteSpace: 'nowrap', fontSize: '0.75rem' }}>
+                    {u.latest_incident ? new Date(u.latest_incident).toLocaleDateString() : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/server/api/incidents.py
+++ b/server/api/incidents.py
@@ -31,8 +31,11 @@ from server.schemas.incident import (
     IncidentNoteResponse,
     IncidentResponse,
     IncidentUpdate,
+    SmartResponseRequest,
+    SmartResponseResult,
 )
 from server.services import incident_service
+from server.services import smart_response
 
 logger = logging.getLogger(__name__)
 
@@ -212,6 +215,42 @@ async def add_note(
     )
     await db.commit()
     return note
+
+
+# ---------------------------------------------------------------------------
+# Smart Response
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{incident_id}/respond", response_model=SmartResponseResult)
+async def smart_respond(
+    incident_id: uuid.UUID,
+    body: SmartResponseRequest,
+    request: Request,
+    user: CurrentUser = Depends(RequirePermission("incidents:write")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Execute a smart response action on an incident."""
+    outcome = await smart_response.execute(
+        db,
+        incident_id=incident_id,
+        actor_id=user.id,
+        action=body.action,
+        params=body.params,
+    )
+
+    if outcome.success:
+        await _audit(
+            db, user, f"incident.smart_response.{body.action}", request,
+            resource_id=str(incident_id),
+            detail=outcome.detail,
+        )
+
+    return SmartResponseResult(
+        success=outcome.success,
+        action=outcome.action,
+        detail=outcome.detail,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/server/api/reports.py
+++ b/server/api/reports.py
@@ -1,0 +1,362 @@
+"""Reports & User Risk API endpoints (P8-T7).
+
+Endpoints:
+  POST   /api/reports/summary            — Generate summary report (JSON)
+  POST   /api/reports/detail             — Generate detail report (JSON)
+  POST   /api/reports/summary/csv        — Export summary as CSV
+  POST   /api/reports/detail/csv         — Export detail as CSV
+  POST   /api/reports/trend              — Generate trend report (JSON)
+  GET    /api/reports/risk               — User risk scores
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import PlainTextResponse
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.api.dependencies import CurrentUser, RequirePermission
+from server.database import get_db
+from server.models.incident import Incident
+from server.services.report_generator import (
+    IncidentRecord,
+    generate_detail,
+    generate_summary,
+    generate_trend,
+)
+from server.services.report_exporter import (
+    export_detail_csv,
+    export_summary_csv,
+    export_trend_csv,
+)
+from server.services.risk_calculator import (
+    calculate_user_risk,
+    get_risk_level,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/reports", tags=["reports"])
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas
+# ---------------------------------------------------------------------------
+
+
+class ReportRequest(BaseModel):
+    start_date: datetime | None = None
+    end_date: datetime | None = None
+    severity: str | None = None
+    channel: str | None = None
+    policy_name: str | None = None
+
+
+class TrendRequest(BaseModel):
+    start_date: datetime | None = None
+    end_date: datetime | None = None
+    previous_start: datetime | None = None
+    previous_end: datetime | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_range() -> tuple[datetime, datetime]:
+    """Default to last 30 days."""
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=30)
+    return start, end
+
+
+async def _fetch_incidents(
+    db: AsyncSession,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    severity: str | None = None,
+    channel: str | None = None,
+    policy_name: str | None = None,
+) -> list[IncidentRecord]:
+    """Fetch incidents from DB and convert to IncidentRecord."""
+    start, end = start_date, end_date
+    if start is None or end is None:
+        d_start, d_end = _default_range()
+        start = start or d_start
+        end = end or d_end
+
+    # Ensure timezone aware
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
+
+    stmt = (
+        select(Incident)
+        .where(Incident.created_at >= start)
+        .where(Incident.created_at <= end)
+    )
+
+    if severity:
+        stmt = stmt.where(Incident.severity == severity)
+    if channel:
+        stmt = stmt.where(Incident.channel == channel)
+    if policy_name:
+        stmt = stmt.where(Incident.policy_name.ilike(f"%{policy_name}%"))
+
+    result = await db.execute(stmt)
+    rows = result.scalars().all()
+
+    records = []
+    for r in rows:
+        records.append(IncidentRecord(
+            id=str(r.id),
+            policy_name=r.policy_name,
+            severity=r.severity.value if hasattr(r.severity, "value") else str(r.severity),
+            status=r.status.value if hasattr(r.status, "value") else str(r.status),
+            channel=r.channel.value if hasattr(r.channel, "value") else str(r.channel),
+            source_type=r.source_type or "unknown",
+            user=r.user,
+            file_name=r.file_name,
+            action_taken=r.action_taken or "log",
+            match_count=r.match_count,
+            created_at=r.created_at,
+        ))
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+
+@router.post("/summary")
+async def summary_report(
+    body: ReportRequest,
+    user: CurrentUser = Depends(RequirePermission("incidents:read")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Generate an incident summary report."""
+    incidents = await _fetch_incidents(
+        db, body.start_date, body.end_date,
+        body.severity, body.channel, body.policy_name,
+    )
+    start, end = body.start_date, body.end_date
+    if not start or not end:
+        d_start, d_end = _default_range()
+        start = start or d_start
+        end = end or d_end
+
+    report = generate_summary(incidents, start, end)
+    return _summary_to_dict(report)
+
+
+@router.post("/summary/csv")
+async def summary_csv(
+    body: ReportRequest,
+    user: CurrentUser = Depends(RequirePermission("incidents:read")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Export summary report as CSV."""
+    incidents = await _fetch_incidents(
+        db, body.start_date, body.end_date,
+        body.severity, body.channel, body.policy_name,
+    )
+    start, end = body.start_date, body.end_date
+    if not start or not end:
+        d_start, d_end = _default_range()
+        start = start or d_start
+        end = end or d_end
+
+    report = generate_summary(incidents, start, end)
+    csv_content = export_summary_csv(report)
+    return PlainTextResponse(
+        content=csv_content,
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=summary_report.csv"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Detail
+# ---------------------------------------------------------------------------
+
+
+@router.post("/detail")
+async def detail_report(
+    body: ReportRequest,
+    user: CurrentUser = Depends(RequirePermission("incidents:read")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Generate an incident detail report."""
+    incidents = await _fetch_incidents(
+        db, body.start_date, body.end_date,
+        body.severity, body.channel, body.policy_name,
+    )
+    start, end = body.start_date, body.end_date
+    if not start or not end:
+        d_start, d_end = _default_range()
+        start = start or d_start
+        end = end or d_end
+
+    report = generate_detail(incidents, start, end)
+    return {
+        "start_date": report.start_date.isoformat(),
+        "end_date": report.end_date.isoformat(),
+        "total_incidents": report.total_incidents,
+        "incidents": [
+            {
+                "id": inc.id,
+                "policy_name": inc.policy_name,
+                "severity": inc.severity,
+                "status": inc.status,
+                "channel": inc.channel,
+                "source_type": inc.source_type,
+                "user": inc.user,
+                "file_name": inc.file_name,
+                "action_taken": inc.action_taken,
+                "match_count": inc.match_count,
+                "created_at": inc.created_at.isoformat() if hasattr(inc.created_at, "isoformat") else str(inc.created_at),
+            }
+            for inc in report.incidents
+        ],
+    }
+
+
+@router.post("/detail/csv")
+async def detail_csv(
+    body: ReportRequest,
+    user: CurrentUser = Depends(RequirePermission("incidents:read")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Export detail report as CSV."""
+    incidents = await _fetch_incidents(
+        db, body.start_date, body.end_date,
+        body.severity, body.channel, body.policy_name,
+    )
+    start, end = body.start_date, body.end_date
+    if not start or not end:
+        d_start, d_end = _default_range()
+        start = start or d_start
+        end = end or d_end
+
+    report = generate_detail(incidents, start, end)
+    csv_content = export_detail_csv(report)
+    return PlainTextResponse(
+        content=csv_content,
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=detail_report.csv"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trend
+# ---------------------------------------------------------------------------
+
+
+@router.post("/trend")
+async def trend_report(
+    body: TrendRequest,
+    user: CurrentUser = Depends(RequirePermission("incidents:read")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Generate a trend comparison report."""
+    start, end = body.start_date, body.end_date
+    if not start or not end:
+        d_start, d_end = _default_range()
+        start = start or d_start
+        end = end or d_end
+
+    # Current period
+    current_incidents = await _fetch_incidents(db, start, end)
+
+    # Previous period
+    if body.previous_start and body.previous_end:
+        prev_incidents = await _fetch_incidents(db, body.previous_start, body.previous_end)
+        prev_start, prev_end = body.previous_start, body.previous_end
+    else:
+        # Auto-calculate previous period of same duration
+        duration = end - start
+        prev_end = start
+        prev_start = start - duration
+        prev_incidents = await _fetch_incidents(db, prev_start, prev_end)
+
+    report = generate_trend(current_incidents, prev_incidents, start, end, prev_start, prev_end)
+    return {
+        "current_period": _summary_to_dict(report.current_period),
+        "previous_period": _summary_to_dict(report.previous_period),
+        "deltas": [
+            {
+                "metric": d.metric,
+                "current_value": d.current_value,
+                "previous_value": d.previous_value,
+                "delta": d.delta,
+                "delta_percent": d.delta_percent,
+            }
+            for d in report.deltas
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# User Risk
+# ---------------------------------------------------------------------------
+
+
+@router.get("/risk")
+async def user_risk(
+    user: CurrentUser = Depends(RequirePermission("incidents:read")),
+    db: AsyncSession = Depends(get_db),
+    days: int = Query(default=90, ge=1, le=365),
+):
+    """Get user risk scores based on incident history."""
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=days)
+
+    incidents = await _fetch_incidents(db, start, end)
+    report = calculate_user_risk(incidents, reference_time=end)
+
+    return {
+        "generated_at": report.generated_at.isoformat(),
+        "lookback_days": days,
+        "users": [
+            {
+                "user": s.user,
+                "raw_score": s.raw_score,
+                "normalized_score": s.normalized_score,
+                "risk_level": get_risk_level(s.normalized_score),
+                "incident_count": s.incident_count,
+                "severity_breakdown": s.severity_breakdown,
+                "latest_incident": s.latest_incident.isoformat() if s.latest_incident else None,
+                "oldest_incident": s.oldest_incident.isoformat() if s.oldest_incident else None,
+            }
+            for s in report.scores
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Serialization helpers
+# ---------------------------------------------------------------------------
+
+
+def _summary_to_dict(report) -> dict:
+    """Convert SummaryReport to JSON-serializable dict."""
+    return {
+        "start_date": report.start_date.isoformat(),
+        "end_date": report.end_date.isoformat(),
+        "total_incidents": report.total_incidents,
+        "by_severity": [{"key": b.key, "count": b.count, "percentage": b.percentage} for b in report.by_severity],
+        "by_policy": [{"key": b.key, "count": b.count, "percentage": b.percentage} for b in report.by_policy],
+        "by_channel": [{"key": b.key, "count": b.count, "percentage": b.percentage} for b in report.by_channel],
+        "by_status": [{"key": b.key, "count": b.count, "percentage": b.percentage} for b in report.by_status],
+        "by_source_type": [{"key": b.key, "count": b.count, "percentage": b.percentage} for b in report.by_source_type],
+        "top_users": [{"key": b.key, "count": b.count, "percentage": b.percentage} for b in report.top_users],
+    }

--- a/server/main.py
+++ b/server/main.py
@@ -15,18 +15,29 @@ from server.api.search import router as search_router
 from server.api.system import router as system_router
 from server.api.fingerprints import router as fingerprints_router
 from server.api.network_settings import router as network_settings_router
+from server.api.reports import router as reports_router
 from server.api.users import router as users_router
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup — launch gRPC server alongside FastAPI
-    from server.grpc_server import serve as grpc_serve
+    grpc_server = None
+    try:
+        from server.grpc_server import serve as grpc_serve
 
-    grpc_server = await grpc_serve(port=settings.grpc_port)
+        grpc_server = await grpc_serve(port=settings.grpc_port)
+    except Exception as exc:
+        import logging
+        logging.getLogger(__name__).warning(
+            "gRPC server failed to start (port %s): %s — "
+            "API will run without agent gRPC. Kill the stale process to restore.",
+            settings.grpc_port, exc,
+        )
     yield
     # Shutdown
-    await grpc_server.stop(grace=5)
+    if grpc_server is not None:
+        await grpc_server.stop(grace=5)
 
 
 app = FastAPI(
@@ -53,6 +64,7 @@ app.include_router(fingerprints_router)
 app.include_router(incidents_router)
 app.include_router(network_settings_router)
 app.include_router(policies_router)
+app.include_router(reports_router)
 app.include_router(response_rules_router)
 app.include_router(search_router)
 app.include_router(system_router)

--- a/server/scripts/seed_incidents.py
+++ b/server/scripts/seed_incidents.py
@@ -1,0 +1,226 @@
+"""
+Seed script for test incidents — populates realistic DLP data.
+
+Creates ~75 incidents across:
+  - 6 policies (PCI-DSS, HIPAA, GDPR, SOX, Source Code, Confidential)
+  - 5 severity levels
+  - 7 channels
+  - 8 users
+  - Various statuses and actions
+  - Spread over the last 60 days
+
+Usage:
+  python -m server.scripts.seed_incidents
+"""
+
+import asyncio
+import random
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from server.database import async_session
+from server.models.incident import Channel, Incident, IncidentNote, IncidentStatus
+from server.models.policy import Severity
+
+
+# ---------------------------------------------------------------------------
+# Data pools
+# ---------------------------------------------------------------------------
+
+USERS = [
+    "jsmith", "mwilliams", "acheng", "kpatel",
+    "rjohnson", "lgarcia", "tnguyen", "bthompson",
+]
+
+POLICIES = [
+    {"name": "PCI-DSS: Credit Card Detection", "severity": Severity.HIGH},
+    {"name": "HIPAA: Protected Health Information", "severity": Severity.HIGH},
+    {"name": "GDPR: EU Personal Data Protection", "severity": Severity.HIGH},
+    {"name": "SOX: Financial Data Protection", "severity": Severity.MEDIUM},
+    {"name": "Source Code Leakage Prevention", "severity": Severity.MEDIUM},
+    {"name": "Confidential Document Detection", "severity": Severity.CRITICAL},
+]
+
+CHANNELS = list(Channel)
+
+ACTIONS = ["block", "notify", "log", "quarantine"]
+SOURCE_TYPES = ["endpoint", "network", "discover"]
+
+FILES = [
+    ("customer_list.xlsx", "C:\\Users\\{user}\\Documents\\customer_list.xlsx", 245760, "xlsx"),
+    ("Q4_financials.pdf", "C:\\Users\\{user}\\Desktop\\Q4_financials.pdf", 1048576, "pdf"),
+    ("patient_records.csv", "C:\\Shared\\hr\\patient_records.csv", 512000, "csv"),
+    ("api_keys.env", "C:\\Projects\\backend\\.env", 2048, "env"),
+    ("merger_deck.pptx", "C:\\Users\\{user}\\Downloads\\merger_deck.pptx", 5242880, "pptx"),
+    ("employee_ssn.txt", "C:\\Users\\{user}\\Desktop\\employee_ssn.txt", 8192, "txt"),
+    ("source_dump.zip", "C:\\Users\\{user}\\Downloads\\source_dump.zip", 10485760, "zip"),
+    ("board_minutes.docx", "C:\\Users\\{user}\\Documents\\board_minutes.docx", 327680, "docx"),
+    ("passport_scans.pdf", "C:\\Shared\\onboarding\\passport_scans.pdf", 2097152, "pdf"),
+    ("salary_report.xlsx", "C:\\Users\\{user}\\Desktop\\salary_report.xlsx", 163840, "xlsx"),
+    (None, None, None, None),  # no file context
+    (None, None, None, None),
+]
+
+DESTINATIONS = [
+    "https://drive.google.com/upload",
+    "https://dropbox.com/share",
+    "smb://fileserver/public",
+    "usb://SANDISK-32GB",
+    "mailto:personal@gmail.com",
+    "https://pastebin.com/new",
+    None,
+    None,
+]
+
+MATCHED_CONTENT_SAMPLES = [
+    {"matches": [{"type": "credit_card", "value": "4532-XXXX-XXXX-0366", "count": 3}]},
+    {"matches": [{"type": "ssn", "value": "XXX-XX-6789", "count": 1}]},
+    {"matches": [{"type": "iban", "value": "GB29NWBK60XXXX26819", "count": 2}]},
+    {"matches": [{"type": "keyword", "value": "CONFIDENTIAL", "count": 5}]},
+    {"matches": [{"type": "api_key", "value": "sk-...XXX", "count": 1}]},
+    {"matches": [{"type": "email", "value": "user@***.com", "count": 4}]},
+]
+
+NOTES = [
+    "Reviewed — confirmed policy violation. User was copying PII to USB.",
+    "False positive — this is test data from the QA environment.",
+    "Escalated to CISO per incident response playbook.",
+    "User acknowledged the violation and completed security training.",
+    "Working with HR to investigate repeated data exfiltration attempts.",
+    "Resolved — file was encrypted and approved for external transfer.",
+]
+
+
+# ---------------------------------------------------------------------------
+# Generator
+# ---------------------------------------------------------------------------
+
+
+def _random_dt(days_back: int = 60) -> datetime:
+    """Random datetime within the last N days."""
+    offset = random.random() * days_back * 86400
+    return datetime.now(timezone.utc) - timedelta(seconds=offset)
+
+
+def _make_incident(user: str, policy: dict, dt: datetime) -> Incident:
+    """Build a single random incident."""
+    file_name, file_path, file_size, file_type = random.choice(FILES)
+    if file_path and "{user}" in file_path:
+        file_path = file_path.replace("{user}", user)
+
+    channel = random.choice(CHANNELS)
+    source_type = random.choice(SOURCE_TYPES)
+
+    # Weight actions: block more for critical/high
+    if policy["severity"] in (Severity.CRITICAL, Severity.HIGH):
+        action = random.choices(ACTIONS, weights=[40, 30, 20, 10])[0]
+    else:
+        action = random.choices(ACTIONS, weights=[10, 30, 50, 10])[0]
+
+    # Weight statuses: most should be new or in_progress for realism
+    status = random.choices(
+        list(IncidentStatus),
+        weights=[35, 25, 20, 10, 10],
+    )[0]
+
+    severity = policy["severity"]
+    # Occasionally override severity for variety
+    if random.random() < 0.2:
+        severity = random.choice(list(Severity))
+
+    return Incident(
+        policy_name=policy["name"],
+        severity=severity,
+        status=status,
+        channel=channel,
+        source_type=source_type,
+        file_path=file_path,
+        file_name=file_name,
+        file_size=file_size,
+        file_type=file_type,
+        user=user,
+        source_ip=f"10.0.{random.randint(1, 254)}.{random.randint(1, 254)}",
+        destination=random.choice(DESTINATIONS),
+        match_count=random.randint(1, 15),
+        matched_content=random.choice(MATCHED_CONTENT_SAMPLES),
+        data_identifiers={"identifiers": ["credit_card", "ssn", "iban"][:random.randint(1, 3)]},
+        action_taken=action,
+        user_justification=random.choice([None, None, "Business need", "Approved by manager"]),
+        created_at=dt,
+        updated_at=dt,
+    )
+
+
+async def seed_incidents():
+    print("AkesoDLP Incident Seed Script")
+    print("=" * 50)
+
+    # Make some users more "risky" than others
+    risky_users = random.sample(USERS, 3)
+    normal_users = [u for u in USERS if u not in risky_users]
+
+    incidents: list[Incident] = []
+
+    # Risky users: 10-15 incidents each, more recent, more critical
+    for user in risky_users:
+        count = random.randint(10, 15)
+        for _ in range(count):
+            policy = random.choices(POLICIES, weights=[20, 15, 15, 10, 10, 30])[0]
+            dt = _random_dt(30)  # More recent
+            incidents.append(_make_incident(user, policy, dt))
+
+    # Normal users: 2-6 incidents each, spread over 60 days
+    for user in normal_users:
+        count = random.randint(2, 6)
+        for _ in range(count):
+            policy = random.choice(POLICIES)
+            dt = _random_dt(60)
+            incidents.append(_make_incident(user, policy, dt))
+
+    print(f"\nGenerating {len(incidents)} incidents...")
+    print(f"  Risky users (10-15 incidents): {', '.join(risky_users)}")
+    print(f"  Normal users (2-6 incidents): {', '.join(normal_users)}")
+
+    async with async_session() as session:
+        session.add_all(incidents)
+        await session.flush()
+
+        # Add notes to ~30% of incidents
+        note_count = 0
+        for inc in incidents:
+            if random.random() < 0.3:
+                note = IncidentNote(
+                    incident_id=inc.id,
+                    content=random.choice(NOTES),
+                )
+                session.add(note)
+                note_count += 1
+
+        await session.commit()
+
+    # Summary
+    severity_counts = {}
+    status_counts = {}
+    for inc in incidents:
+        sev = inc.severity.value if hasattr(inc.severity, "value") else str(inc.severity)
+        st = inc.status.value if hasattr(inc.status, "value") else str(inc.status)
+        severity_counts[sev] = severity_counts.get(sev, 0) + 1
+        status_counts[st] = status_counts.get(st, 0) + 1
+
+    print(f"\nCreated {len(incidents)} incidents + {note_count} notes")
+    print(f"\nBy severity:")
+    for sev, count in sorted(severity_counts.items()):
+        print(f"  {sev}: {count}")
+    print(f"\nBy status:")
+    for st, count in sorted(status_counts.items()):
+        print(f"  {st}: {count}")
+    print(f"\n{'=' * 50}")
+    print("Done! Start the server and explore the console.")
+
+
+def main():
+    asyncio.run(seed_incidents())
+
+
+if __name__ == "__main__":
+    main()

--- a/server/services/report_exporter.py
+++ b/server/services/report_exporter.py
@@ -1,0 +1,358 @@
+"""Report exporter — CSV and PDF export (P8-T2).
+
+Exports SummaryReport and DetailReport to:
+  - CSV: Excel-compatible UTF-8 with BOM, one row per incident (detail)
+    or one row per aggregation bucket (summary).
+  - PDF: Formatted with tables using reportlab (if available) or a
+    lightweight HTML-to-text fallback.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+from dataclasses import asdict
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from server.services.report_generator import (
+    AggregationBucket,
+    DetailReport,
+    IncidentRecord,
+    SummaryReport,
+    TrendDelta,
+    TrendReport,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# --- CSV Export ---
+
+
+def export_detail_csv(report: DetailReport) -> str:
+    """Export a detail report to CSV string.
+
+    Returns UTF-8 CSV with BOM for Excel compatibility.
+    """
+    output = io.StringIO()
+    output.write("\ufeff")  # BOM for Excel
+
+    writer = csv.writer(output)
+
+    # Header
+    writer.writerow([
+        "ID", "Policy", "Severity", "Status", "Channel",
+        "Source Type", "User", "File Name", "Action Taken",
+        "Match Count", "Created At",
+    ])
+
+    for inc in report.incidents:
+        writer.writerow([
+            inc.id,
+            inc.policy_name,
+            inc.severity,
+            inc.status,
+            inc.channel,
+            inc.source_type,
+            inc.user or "",
+            inc.file_name or "",
+            inc.action_taken,
+            inc.match_count,
+            inc.created_at.isoformat() if isinstance(inc.created_at, datetime) else str(inc.created_at),
+        ])
+
+    return output.getvalue()
+
+
+def export_summary_csv(report: SummaryReport) -> str:
+    """Export a summary report to CSV string.
+
+    Produces multiple sections: overview, then one section per aggregation.
+    """
+    output = io.StringIO()
+    output.write("\ufeff")  # BOM
+
+    writer = csv.writer(output)
+
+    # Overview section
+    writer.writerow(["Summary Report"])
+    writer.writerow(["Period", f"{report.start_date.date()} to {report.end_date.date()}"])
+    writer.writerow(["Total Incidents", report.total_incidents])
+    writer.writerow([])
+
+    sections = [
+        ("By Severity", report.by_severity),
+        ("By Policy", report.by_policy),
+        ("By Channel", report.by_channel),
+        ("By Status", report.by_status),
+        ("By Source Type", report.by_source_type),
+        ("Top Users", report.top_users),
+    ]
+
+    for title, buckets in sections:
+        writer.writerow([title])
+        writer.writerow(["Category", "Count", "Percentage"])
+        for b in buckets:
+            writer.writerow([b.key, b.count, f"{b.percentage}%"])
+        writer.writerow([])
+
+    return output.getvalue()
+
+
+def export_trend_csv(report: TrendReport) -> str:
+    """Export a trend comparison report to CSV string."""
+    output = io.StringIO()
+    output.write("\ufeff")  # BOM
+
+    writer = csv.writer(output)
+
+    writer.writerow(["Trend Report"])
+    writer.writerow([
+        "Current Period",
+        f"{report.current_period.start_date.date()} to {report.current_period.end_date.date()}",
+    ])
+    writer.writerow([
+        "Previous Period",
+        f"{report.previous_period.start_date.date()} to {report.previous_period.end_date.date()}",
+    ])
+    writer.writerow([])
+
+    writer.writerow(["Metric", "Current", "Previous", "Delta", "Change %"])
+    for d in report.deltas:
+        writer.writerow([
+            d.metric.replace("_", " ").title(),
+            d.current_value,
+            d.previous_value,
+            f"{'+' if d.delta > 0 else ''}{d.delta}",
+            f"{'+' if d.delta_percent > 0 else ''}{d.delta_percent}%",
+        ])
+
+    return output.getvalue()
+
+
+# --- PDF Export ---
+
+
+def export_detail_pdf(report: DetailReport) -> bytes:
+    """Export a detail report to PDF bytes.
+
+    Uses reportlab if available, otherwise falls back to a simple
+    text-based PDF.
+    """
+    try:
+        return _export_detail_pdf_reportlab(report)
+    except ImportError:
+        logger.info("reportlab not available, using text-based PDF fallback")
+        return _export_text_pdf(
+            title="Incident Detail Report",
+            subtitle=f"Period: {report.start_date.date()} to {report.end_date.date()}",
+            body=_detail_to_text(report),
+        )
+
+
+def export_summary_pdf(report: SummaryReport) -> bytes:
+    """Export a summary report to PDF bytes."""
+    try:
+        return _export_summary_pdf_reportlab(report)
+    except ImportError:
+        logger.info("reportlab not available, using text-based PDF fallback")
+        return _export_text_pdf(
+            title="Incident Summary Report",
+            subtitle=f"Period: {report.start_date.date()} to {report.end_date.date()}",
+            body=_summary_to_text(report),
+        )
+
+
+# --- reportlab implementations ---
+
+
+def _export_detail_pdf_reportlab(report: DetailReport) -> bytes:
+    """Generate detail PDF using reportlab."""
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import letter, landscape
+    from reportlab.lib.units import inch
+    from reportlab.platypus import (
+        SimpleDocTemplate,
+        Table,
+        TableStyle,
+        Paragraph,
+        Spacer,
+    )
+    from reportlab.lib.styles import getSampleStyleSheet
+
+    buf = io.BytesIO()
+    doc = SimpleDocTemplate(buf, pagesize=landscape(letter))
+    styles = getSampleStyleSheet()
+    elements = []
+
+    # Title
+    elements.append(Paragraph("Incident Detail Report", styles["Title"]))
+    elements.append(Paragraph(
+        f"Period: {report.start_date.date()} to {report.end_date.date()} "
+        f"| Total: {report.total_incidents}",
+        styles["Normal"],
+    ))
+    elements.append(Spacer(1, 0.25 * inch))
+
+    # Table
+    headers = ["Policy", "Severity", "Status", "Channel", "User", "Action", "Date"]
+    data = [headers]
+    for inc in report.incidents[:500]:  # Cap at 500 rows for PDF
+        data.append([
+            inc.policy_name[:30],
+            inc.severity,
+            inc.status,
+            inc.channel,
+            (inc.user or "")[:20],
+            inc.action_taken,
+            inc.created_at.strftime("%Y-%m-%d %H:%M") if isinstance(inc.created_at, datetime) else str(inc.created_at),
+        ])
+
+    table = Table(data, repeatRows=1)
+    table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#1e293b")),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("FONTSIZE", (0, 0), (-1, -1), 8),
+        ("FONTSIZE", (0, 0), (-1, 0), 9),
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, colors.HexColor("#f1f5f9")]),
+        ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#cbd5e1")),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+    ]))
+    elements.append(table)
+
+    doc.build(elements)
+    return buf.getvalue()
+
+
+def _export_summary_pdf_reportlab(report: SummaryReport) -> bytes:
+    """Generate summary PDF using reportlab."""
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib.units import inch
+    from reportlab.platypus import (
+        SimpleDocTemplate,
+        Table,
+        TableStyle,
+        Paragraph,
+        Spacer,
+    )
+    from reportlab.lib.styles import getSampleStyleSheet
+
+    buf = io.BytesIO()
+    doc = SimpleDocTemplate(buf, pagesize=letter)
+    styles = getSampleStyleSheet()
+    elements = []
+
+    elements.append(Paragraph("Incident Summary Report", styles["Title"]))
+    elements.append(Paragraph(
+        f"Period: {report.start_date.date()} to {report.end_date.date()} "
+        f"| Total Incidents: {report.total_incidents}",
+        styles["Normal"],
+    ))
+    elements.append(Spacer(1, 0.3 * inch))
+
+    sections = [
+        ("By Severity", report.by_severity),
+        ("By Policy", report.by_policy),
+        ("By Channel", report.by_channel),
+        ("By Status", report.by_status),
+        ("By Source Type", report.by_source_type),
+        ("Top Users", report.top_users),
+    ]
+
+    for title, buckets in sections:
+        if not buckets:
+            continue
+        elements.append(Paragraph(title, styles["Heading2"]))
+        data = [["Category", "Count", "%"]]
+        for b in buckets:
+            data.append([b.key, str(b.count), f"{b.percentage}%"])
+
+        table = Table(data, colWidths=[3 * inch, 1.5 * inch, 1 * inch])
+        table.setStyle(TableStyle([
+            ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#1e293b")),
+            ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+            ("FONTSIZE", (0, 0), (-1, -1), 9),
+            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+            ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, colors.HexColor("#f1f5f9")]),
+            ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#cbd5e1")),
+        ]))
+        elements.append(table)
+        elements.append(Spacer(1, 0.2 * inch))
+
+    doc.build(elements)
+    return buf.getvalue()
+
+
+# --- Text-based PDF fallback ---
+
+
+def _export_text_pdf(title: str, subtitle: str, body: str) -> bytes:
+    """Minimal PDF without external dependencies.
+
+    Produces a valid PDF 1.4 with embedded text content.
+    """
+    lines = [title, subtitle, "=" * 60, "", body]
+    text = "\n".join(lines)
+
+    # Minimal PDF structure
+    content = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+    stream = f"BT /F1 10 Tf 50 750 Td ({content[:3000]}) Tj ET"
+
+    pdf = (
+        "%PDF-1.4\n"
+        "1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+        "2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+        "3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]"
+        "/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj\n"
+        f"4 0 obj<</Length {len(stream)}>>stream\n{stream}\nendstream\nendobj\n"
+        "5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Courier>>endobj\n"
+        "xref\n0 6\n"
+        "0000000000 65535 f \n"
+        "0000000009 00000 n \n"
+        "0000000058 00000 n \n"
+        "0000000115 00000 n \n"
+        f"0000000266 00000 n \n"
+        f"0000000{266 + len(stream) + 44:03d} 00000 n \n"
+        "trailer<</Root 1 0 R/Size 6>>\nstartxref\n9\n%%EOF\n"
+    )
+    return pdf.encode("latin-1")
+
+
+def _detail_to_text(report: DetailReport) -> str:
+    """Convert detail report to plain text."""
+    lines = [f"Total Incidents: {report.total_incidents}", ""]
+    for inc in report.incidents[:100]:
+        lines.append(
+            f"[{inc.severity.upper()}] {inc.policy_name} | "
+            f"{inc.channel} | {inc.user or 'N/A'} | "
+            f"{inc.action_taken} | {inc.created_at}"
+        )
+    if report.total_incidents > 100:
+        lines.append(f"... and {report.total_incidents - 100} more")
+    return "\n".join(lines)
+
+
+def _summary_to_text(report: SummaryReport) -> str:
+    """Convert summary report to plain text."""
+    lines = [f"Total Incidents: {report.total_incidents}", ""]
+
+    sections = [
+        ("By Severity", report.by_severity),
+        ("By Policy", report.by_policy),
+        ("By Channel", report.by_channel),
+        ("By Status", report.by_status),
+    ]
+
+    for title, buckets in sections:
+        lines.append(f"--- {title} ---")
+        for b in buckets:
+            lines.append(f"  {b.key}: {b.count} ({b.percentage}%)")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/server/services/report_generator.py
+++ b/server/services/report_generator.py
@@ -1,0 +1,253 @@
+"""Report generator — summary and detail reports with trend comparison (P8-T1).
+
+Generates two report types from incident data:
+  - Summary: counts aggregated by severity, policy, source, status, channel.
+  - Detail: full incident list within a date range.
+
+Trend comparison computes deltas between two equal-length periods,
+e.g., this month vs last month.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class IncidentRecord:
+    """Lightweight incident representation for reporting.
+
+    Decoupled from the DB model so reports can be generated
+    from any data source (DB query results, JSON imports, etc.).
+    """
+
+    id: str
+    policy_name: str
+    severity: str  # critical, high, medium, low, info
+    status: str  # new, in_progress, resolved, dismissed, escalated
+    channel: str  # usb, email, http_upload, etc.
+    source_type: str  # endpoint, network
+    user: str | None = None
+    file_name: str | None = None
+    action_taken: str = "log"
+    match_count: int = 0
+    created_at: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class AggregationBucket:
+    """A single aggregation group with its count."""
+
+    key: str
+    count: int
+    percentage: float = 0.0
+
+
+@dataclass
+class SummaryReport:
+    """Aggregated summary report."""
+
+    start_date: datetime
+    end_date: datetime
+    total_incidents: int
+    by_severity: list[AggregationBucket]
+    by_policy: list[AggregationBucket]
+    by_channel: list[AggregationBucket]
+    by_status: list[AggregationBucket]
+    by_source_type: list[AggregationBucket]
+    top_users: list[AggregationBucket]
+
+
+@dataclass
+class TrendDelta:
+    """Comparison between two periods."""
+
+    metric: str
+    current_value: int
+    previous_value: int
+    delta: int
+    delta_percent: float  # e.g., +25.0 or -10.5
+
+
+@dataclass
+class TrendReport:
+    """Period-over-period trend comparison."""
+
+    current_period: SummaryReport
+    previous_period: SummaryReport
+    deltas: list[TrendDelta]
+
+
+@dataclass
+class DetailReport:
+    """Full incident list report."""
+
+    start_date: datetime
+    end_date: datetime
+    total_incidents: int
+    incidents: list[IncidentRecord]
+
+
+def _aggregate(
+    incidents: list[IncidentRecord],
+    key_fn,
+    total: int,
+) -> list[AggregationBucket]:
+    """Group incidents by a key function and return sorted buckets."""
+    counts: dict[str, int] = {}
+    for inc in incidents:
+        k = key_fn(inc) or "unknown"
+        counts[k] = counts.get(k, 0) + 1
+
+    buckets = [
+        AggregationBucket(
+            key=k,
+            count=c,
+            percentage=round((c / total) * 100, 1) if total > 0 else 0.0,
+        )
+        for k, c in counts.items()
+    ]
+    buckets.sort(key=lambda b: b.count, reverse=True)
+    return buckets
+
+
+def generate_summary(
+    incidents: list[IncidentRecord],
+    start_date: datetime,
+    end_date: datetime,
+) -> SummaryReport:
+    """Generate a summary report from incident records within a date range.
+
+    Args:
+        incidents: All incidents (will be filtered to date range).
+        start_date: Inclusive start of report period.
+        end_date: Inclusive end of report period.
+
+    Returns:
+        SummaryReport with aggregations.
+    """
+    filtered = [
+        i for i in incidents if start_date <= i.created_at <= end_date
+    ]
+    total = len(filtered)
+
+    return SummaryReport(
+        start_date=start_date,
+        end_date=end_date,
+        total_incidents=total,
+        by_severity=_aggregate(filtered, lambda i: i.severity, total),
+        by_policy=_aggregate(filtered, lambda i: i.policy_name, total),
+        by_channel=_aggregate(filtered, lambda i: i.channel, total),
+        by_status=_aggregate(filtered, lambda i: i.status, total),
+        by_source_type=_aggregate(filtered, lambda i: i.source_type, total),
+        top_users=_aggregate(filtered, lambda i: i.user, total),
+    )
+
+
+def generate_detail(
+    incidents: list[IncidentRecord],
+    start_date: datetime,
+    end_date: datetime,
+) -> DetailReport:
+    """Generate a detailed incident list report.
+
+    Args:
+        incidents: All incidents (will be filtered to date range).
+        start_date: Inclusive start of report period.
+        end_date: Inclusive end of report period.
+
+    Returns:
+        DetailReport with full incident list sorted by creation time.
+    """
+    filtered = sorted(
+        [i for i in incidents if start_date <= i.created_at <= end_date],
+        key=lambda i: i.created_at,
+        reverse=True,
+    )
+
+    return DetailReport(
+        start_date=start_date,
+        end_date=end_date,
+        total_incidents=len(filtered),
+        incidents=filtered,
+    )
+
+
+def generate_trend(
+    incidents: list[IncidentRecord],
+    current_start: datetime,
+    current_end: datetime,
+) -> TrendReport:
+    """Generate a period-over-period trend comparison.
+
+    Compares the current period against the immediately preceding
+    period of equal length. E.g., if current is March 1–31, previous
+    is February 1–28.
+
+    Args:
+        incidents: All incidents.
+        current_start: Start of the current period.
+        current_end: End of the current period.
+
+    Returns:
+        TrendReport with current/previous summaries and deltas.
+    """
+    period_length = current_end - current_start
+    previous_end = current_start - timedelta(seconds=1)
+    previous_start = previous_end - period_length
+
+    current = generate_summary(incidents, current_start, current_end)
+    previous = generate_summary(incidents, previous_start, previous_end)
+
+    deltas = []
+
+    # Total incidents delta
+    deltas.append(_compute_delta(
+        "total_incidents", current.total_incidents, previous.total_incidents
+    ))
+
+    # Per-severity deltas
+    severity_order = ["critical", "high", "medium", "low", "info"]
+    for sev in severity_order:
+        curr_count = _find_bucket_count(current.by_severity, sev)
+        prev_count = _find_bucket_count(previous.by_severity, sev)
+        if curr_count > 0 or prev_count > 0:
+            deltas.append(_compute_delta(f"severity_{sev}", curr_count, prev_count))
+
+    return TrendReport(
+        current_period=current,
+        previous_period=previous,
+        deltas=deltas,
+    )
+
+
+def _find_bucket_count(buckets: list[AggregationBucket], key: str) -> int:
+    """Find a bucket's count by key."""
+    for b in buckets:
+        if b.key == key:
+            return b.count
+    return 0
+
+
+def _compute_delta(metric: str, current: int, previous: int) -> TrendDelta:
+    """Compute delta and percentage change."""
+    delta = current - previous
+    if previous > 0:
+        delta_percent = round((delta / previous) * 100, 1)
+    elif current > 0:
+        delta_percent = 100.0  # Went from 0 to something
+    else:
+        delta_percent = 0.0
+
+    return TrendDelta(
+        metric=metric,
+        current_value=current,
+        previous_value=previous,
+        delta=delta,
+        delta_percent=delta_percent,
+    )

--- a/server/services/risk_calculator.py
+++ b/server/services/risk_calculator.py
@@ -1,0 +1,154 @@
+"""User risk scoring — weighted severity with recency decay (P8-T3).
+
+Calculates a risk score per user based on their incident history:
+  - Severity weights: critical=15, high=10, medium=5, low=2, info=1
+  - Recency decay: 0.95^days (exponential decay, older = less weight)
+  - Normalized to 1–100 scale
+
+Score = sum(weight * 0.95^days_ago) for each incident, capped at 100.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Sequence
+
+from server.services.report_generator import IncidentRecord
+
+logger = logging.getLogger(__name__)
+
+
+# Severity weights
+SEVERITY_WEIGHTS: dict[str, int] = {
+    "critical": 15,
+    "high": 10,
+    "medium": 5,
+    "low": 2,
+    "info": 1,
+}
+
+# Decay factor per day
+DECAY_FACTOR = 0.95
+
+# Max score (normalization cap)
+MAX_SCORE = 100
+
+
+@dataclass
+class UserRiskScore:
+    """Risk score for a single user."""
+
+    user: str
+    raw_score: float
+    normalized_score: int  # 1–100
+    incident_count: int
+    severity_breakdown: dict[str, int]  # severity → count
+    latest_incident: datetime | None = None
+    oldest_incident: datetime | None = None
+
+
+@dataclass
+class RiskReport:
+    """Risk scores for all users, sorted by score descending."""
+
+    scores: list[UserRiskScore]
+    generated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+def calculate_user_risk(
+    incidents: list[IncidentRecord],
+    reference_time: datetime | None = None,
+    normalization_cap: float = 50.0,
+) -> RiskReport:
+    """Calculate risk scores for all users with incidents.
+
+    Args:
+        incidents: All incidents to consider.
+        reference_time: Time to calculate recency from (default: now).
+        normalization_cap: Raw score that maps to score=100.
+            Any raw score >= this value is capped at 100.
+            Default 50.0 means 5 high incidents today = 50 raw → 100 normalized.
+
+    Returns:
+        RiskReport with sorted user scores.
+    """
+    if reference_time is None:
+        reference_time = datetime.now(timezone.utc)
+
+    # Ensure reference_time is timezone-aware
+    if reference_time.tzinfo is None:
+        reference_time = reference_time.replace(tzinfo=timezone.utc)
+
+    # Group incidents by user
+    user_incidents: dict[str, list[IncidentRecord]] = {}
+    for inc in incidents:
+        user = inc.user or "unknown"
+        user_incidents.setdefault(user, []).append(inc)
+
+    scores = []
+    for user, user_incs in user_incidents.items():
+        score = _score_user(user, user_incs, reference_time, normalization_cap)
+        scores.append(score)
+
+    # Sort by normalized score descending
+    scores.sort(key=lambda s: s.normalized_score, reverse=True)
+
+    return RiskReport(scores=scores)
+
+
+def _score_user(
+    user: str,
+    incidents: list[IncidentRecord],
+    reference_time: datetime,
+    normalization_cap: float,
+) -> UserRiskScore:
+    """Calculate risk score for a single user."""
+    raw_score = 0.0
+    severity_breakdown: dict[str, int] = {}
+    dates: list[datetime] = []
+
+    for inc in incidents:
+        weight = SEVERITY_WEIGHTS.get(inc.severity, 1)
+        severity_breakdown[inc.severity] = severity_breakdown.get(inc.severity, 0) + 1
+
+        # Calculate days ago
+        inc_time = inc.created_at
+        if inc_time.tzinfo is None:
+            inc_time = inc_time.replace(tzinfo=timezone.utc)
+
+        days_ago = max(0, (reference_time - inc_time).total_seconds() / 86400)
+
+        # Apply decay
+        decayed_weight = weight * (DECAY_FACTOR ** days_ago)
+        raw_score += decayed_weight
+        dates.append(inc_time)
+
+    # Normalize to 1–100
+    normalized = min(MAX_SCORE, int(round((raw_score / normalization_cap) * MAX_SCORE)))
+    normalized = max(1, normalized) if raw_score > 0 else 0
+
+    return UserRiskScore(
+        user=user,
+        raw_score=round(raw_score, 2),
+        normalized_score=normalized,
+        incident_count=len(incidents),
+        severity_breakdown=severity_breakdown,
+        latest_incident=max(dates) if dates else None,
+        oldest_incident=min(dates) if dates else None,
+    )
+
+
+def get_risk_level(score: int) -> str:
+    """Map a normalized risk score to a human-readable level."""
+    if score >= 80:
+        return "critical"
+    if score >= 60:
+        return "high"
+    if score >= 40:
+        return "medium"
+    if score >= 20:
+        return "low"
+    return "minimal"

--- a/server/services/siem_emitter.py
+++ b/server/services/siem_emitter.py
@@ -1,0 +1,288 @@
+"""SIEM emitter — HTTP POST to AkesoSIEM (P8-T5).
+
+Sends DLP events to AkesoSIEM's ingest endpoint via HTTP POST.
+Formats events using Elastic Common Schema (ECS) fields with
+DLP-specific extensions per Section 3.11 of the requirements.
+
+Event types:
+  - dlp:policy_violation — Policy match detected
+  - dlp:file_blocked — File transfer blocked
+  - dlp:incident_created — New incident created
+  - dlp:incident_updated — Incident status changed
+  - dlp:agent_status — Agent heartbeat/status change
+
+All events include:
+  - source_type: "akeso_dlp"
+  - event_type: one of the above
+  - ECS fields: @timestamp, event.*, source.*, user.*, file.*, dlp.*
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+import httpx
+
+from server.services.report_generator import IncidentRecord
+
+logger = logging.getLogger(__name__)
+
+
+class DLPEventType(str, Enum):
+    POLICY_VIOLATION = "dlp:policy_violation"
+    FILE_BLOCKED = "dlp:file_blocked"
+    INCIDENT_CREATED = "dlp:incident_created"
+    INCIDENT_UPDATED = "dlp:incident_updated"
+    AGENT_STATUS = "dlp:agent_status"
+
+
+@dataclass
+class SIEMConfig:
+    """AkesoSIEM integration configuration."""
+
+    endpoint: str = "http://localhost:9200/api/v1/ingest"
+    api_key: str = ""
+    timeout: float = 10.0
+    verify_ssl: bool = True
+    batch_size: int = 100
+    enabled: bool = True
+
+
+def build_ecs_event(
+    incident: IncidentRecord,
+    event_type: DLPEventType = DLPEventType.POLICY_VIOLATION,
+) -> dict[str, Any]:
+    """Build an ECS-formatted event from an incident.
+
+    Args:
+        incident: The incident to format.
+        event_type: The DLP event type.
+
+    Returns:
+        Dictionary with ECS fields ready for JSON serialization.
+    """
+    timestamp = incident.created_at
+    if isinstance(timestamp, datetime):
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        ts_str = timestamp.isoformat()
+    else:
+        ts_str = str(timestamp)
+
+    event: dict[str, Any] = {
+        # Required fields
+        "source_type": "akeso_dlp",
+        "event_type": event_type.value,
+
+        # ECS timestamp
+        "@timestamp": ts_str,
+
+        # ECS event fields
+        "event": {
+            "kind": "alert",
+            "category": ["intrusion_detection"],
+            "type": ["info"],
+            "action": incident.action_taken,
+            "severity": _ecs_severity(incident.severity),
+            "outcome": "success" if incident.action_taken == "block" else "unknown",
+            "module": "akeso_dlp",
+            "dataset": "dlp.incidents",
+        },
+
+        # ECS source fields
+        "source": {
+            "type": incident.source_type,
+        },
+
+        # DLP-specific fields (Section 3.11)
+        "dlp": {
+            "policy": {
+                "name": incident.policy_name,
+            },
+            "classification": incident.severity,
+            "channel": incident.channel,
+            "action": incident.action_taken,
+            "match_count": incident.match_count,
+        },
+
+        # ECS observer (the DLP system)
+        "observer": {
+            "vendor": "AkesoDLP",
+            "product": "AkesoDLP",
+            "type": "dlp",
+        },
+    }
+
+    # Optional ECS fields
+    if incident.user:
+        event["user"] = {"name": incident.user}
+
+    if incident.file_name:
+        event["file"] = {
+            "name": incident.file_name,
+        }
+
+    # Incident ID for correlation
+    event["dlp"]["incident_id"] = incident.id
+
+    return event
+
+
+def build_status_event(
+    agent_id: str,
+    hostname: str,
+    status: str,
+    timestamp: datetime | None = None,
+) -> dict[str, Any]:
+    """Build an agent status event.
+
+    Args:
+        agent_id: The agent's unique identifier.
+        hostname: The agent's hostname.
+        status: Current status (online, offline, error).
+        timestamp: Event time (default: now).
+    """
+    if timestamp is None:
+        timestamp = datetime.now(timezone.utc)
+
+    return {
+        "source_type": "akeso_dlp",
+        "event_type": DLPEventType.AGENT_STATUS.value,
+        "@timestamp": timestamp.isoformat(),
+        "event": {
+            "kind": "event",
+            "category": ["host"],
+            "type": ["info"],
+            "action": "agent_heartbeat",
+            "module": "akeso_dlp",
+            "dataset": "dlp.agents",
+        },
+        "agent": {
+            "id": agent_id,
+            "hostname": hostname,
+        },
+        "observer": {
+            "vendor": "AkesoDLP",
+            "product": "AkesoDLP",
+            "type": "dlp",
+        },
+        "dlp": {
+            "agent_status": status,
+        },
+    }
+
+
+def _ecs_severity(severity: str) -> int:
+    """Map DLP severity to ECS numeric severity (1–4)."""
+    mapping = {"critical": 4, "high": 3, "medium": 2, "low": 1, "info": 0}
+    return mapping.get(severity, 0)
+
+
+class SIEMEmitter:
+    """Sends DLP events to AkesoSIEM via HTTP POST.
+
+    Manages batching, authentication, and error handling.
+    """
+
+    def __init__(self, config: SIEMConfig | None = None):
+        self.config = config or SIEMConfig()
+        self._client: httpx.AsyncClient | None = None
+
+    async def emit(self, event: dict[str, Any]) -> bool:
+        """Send a single event to SIEM.
+
+        Args:
+            event: ECS-formatted event dictionary.
+
+        Returns:
+            True if accepted, False on error.
+        """
+        if not self.config.enabled:
+            return True
+
+        try:
+            client = self._get_client()
+            response = await client.post(
+                self.config.endpoint,
+                json=event,
+                headers=self._auth_headers(),
+            )
+
+            if response.status_code in (200, 201, 202):
+                return True
+            else:
+                logger.warning(
+                    "SIEM rejected event: %d %s",
+                    response.status_code,
+                    response.text[:200],
+                )
+                return False
+
+        except Exception as e:
+            logger.error("Failed to emit SIEM event: %s", e)
+            return False
+
+    async def emit_incident(
+        self,
+        incident: IncidentRecord,
+        event_type: DLPEventType = DLPEventType.POLICY_VIOLATION,
+    ) -> bool:
+        """Build and send an incident event.
+
+        Args:
+            incident: The incident to emit.
+            event_type: The event type classification.
+
+        Returns:
+            True if accepted.
+        """
+        event = build_ecs_event(incident, event_type)
+        return await self.emit(event)
+
+    async def emit_batch(
+        self,
+        incidents: list[IncidentRecord],
+        event_type: DLPEventType = DLPEventType.POLICY_VIOLATION,
+    ) -> tuple[int, int]:
+        """Send a batch of incidents.
+
+        Returns:
+            Tuple of (sent_count, failed_count).
+        """
+        sent = 0
+        failed = 0
+        for inc in incidents:
+            if await self.emit_incident(inc, event_type):
+                sent += 1
+            else:
+                failed += 1
+        return sent, failed
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Get or create the HTTP client."""
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                timeout=self.config.timeout,
+                verify=self.config.verify_ssl,
+            )
+        return self._client
+
+    def _auth_headers(self) -> dict[str, str]:
+        """Build authentication headers."""
+        headers: dict[str, str] = {
+            "Content-Type": "application/json",
+        }
+        if self.config.api_key:
+            headers["Authorization"] = f"ApiKey {self.config.api_key}"
+        return headers
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None

--- a/server/services/smart_response.py
+++ b/server/services/smart_response.py
@@ -1,0 +1,229 @@
+"""Smart Response rules — automated incident actions (P8-T6).
+
+Provides four response actions that can be triggered from the
+incident snapshot page:
+  - add_note: Append a note to the incident
+  - set_status: Change the incident status
+  - send_email: Send a notification email (stub — logs intent)
+  - escalate: Set status to escalated + add note + notify
+
+Each action returns a SmartResponseOutcome with success/failure
+and human-readable detail for the UI toast.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.services import incident_service
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Outcome
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SmartResponseOutcome:
+    """Result of executing a smart response action."""
+
+    success: bool
+    action: str
+    detail: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Action registry
+# ---------------------------------------------------------------------------
+
+VALID_ACTIONS = {"add_note", "set_status", "send_email", "escalate"}
+
+
+async def execute(
+    db: AsyncSession,
+    incident_id: uuid.UUID,
+    actor_id: uuid.UUID,
+    action: str,
+    params: dict[str, Any] | None = None,
+) -> SmartResponseOutcome:
+    """Execute a smart response action on an incident.
+
+    Args:
+        db: Database session.
+        incident_id: Target incident UUID.
+        actor_id: User performing the action.
+        action: One of the VALID_ACTIONS.
+        params: Action-specific parameters.
+
+    Returns:
+        SmartResponseOutcome with success flag and detail message.
+    """
+    params = params or {}
+
+    if action not in VALID_ACTIONS:
+        return SmartResponseOutcome(
+            success=False,
+            action=action,
+            detail=f"Unknown action '{action}'. Valid actions: {', '.join(sorted(VALID_ACTIONS))}",
+        )
+
+    # Look up incident
+    incident = await incident_service.get_incident(db, incident_id)
+    if incident is None:
+        return SmartResponseOutcome(
+            success=False,
+            action=action,
+            detail="Incident not found",
+        )
+
+    try:
+        if action == "add_note":
+            return await _action_add_note(db, incident_id, actor_id, params)
+        elif action == "set_status":
+            return await _action_set_status(db, incident, actor_id, params)
+        elif action == "send_email":
+            return await _action_send_email(db, incident_id, actor_id, params)
+        elif action == "escalate":
+            return await _action_escalate(db, incident, incident_id, actor_id, params)
+        else:
+            return SmartResponseOutcome(success=False, action=action, detail="Not implemented")
+    except Exception as e:
+        logger.error("Smart response '%s' failed for %s: %s", action, incident_id, e)
+        return SmartResponseOutcome(
+            success=False,
+            action=action,
+            detail=f"Action failed: {e}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Individual actions
+# ---------------------------------------------------------------------------
+
+
+async def _action_add_note(
+    db: AsyncSession,
+    incident_id: uuid.UUID,
+    actor_id: uuid.UUID,
+    params: dict[str, Any],
+) -> SmartResponseOutcome:
+    """Append a note to the incident."""
+    content = params.get("content", "").strip()
+    if not content:
+        return SmartResponseOutcome(
+            success=False,
+            action="add_note",
+            detail="Note content is required (params.content)",
+        )
+
+    await incident_service.add_note(db, incident_id, actor_id, content)
+    await db.commit()
+    return SmartResponseOutcome(
+        success=True,
+        action="add_note",
+        detail=f"Note added: {content[:80]}{'...' if len(content) > 80 else ''}",
+    )
+
+
+async def _action_set_status(
+    db: AsyncSession,
+    incident: Any,
+    actor_id: uuid.UUID,
+    params: dict[str, Any],
+) -> SmartResponseOutcome:
+    """Change the incident status."""
+    new_status = params.get("status", "").strip()
+    valid_statuses = {"new", "in_progress", "resolved", "dismissed", "escalated"}
+    if new_status not in valid_statuses:
+        return SmartResponseOutcome(
+            success=False,
+            action="set_status",
+            detail=f"Invalid status '{new_status}'. Valid: {', '.join(sorted(valid_statuses))}",
+        )
+
+    old_status = incident.status.value if hasattr(incident.status, "value") else str(incident.status)
+    await incident_service.update_incident(
+        db, incident, {"status": new_status}, actor_id=actor_id
+    )
+    await db.commit()
+    return SmartResponseOutcome(
+        success=True,
+        action="set_status",
+        detail=f"Status changed from {old_status} to {new_status}",
+    )
+
+
+async def _action_send_email(
+    db: AsyncSession,
+    incident_id: uuid.UUID,
+    actor_id: uuid.UUID,
+    params: dict[str, Any],
+) -> SmartResponseOutcome:
+    """Send an email notification about the incident.
+
+    This is a stub implementation that logs the intent and adds a note.
+    Full SMTP integration is planned for a future sprint.
+    """
+    recipient = params.get("recipient", "").strip()
+    if not recipient:
+        return SmartResponseOutcome(
+            success=False,
+            action="send_email",
+            detail="Recipient email is required (params.recipient)",
+        )
+
+    subject = params.get("subject", "DLP Incident Notification")
+    logger.info(
+        "Email notification queued: to=%s, subject=%s, incident=%s",
+        recipient, subject, incident_id,
+    )
+
+    # Record the action as a note
+    await incident_service.add_note(
+        db, incident_id, actor_id,
+        f"[Smart Response] Email notification sent to {recipient} — Subject: {subject}",
+    )
+    await db.commit()
+    return SmartResponseOutcome(
+        success=True,
+        action="send_email",
+        detail=f"Email notification queued for {recipient}",
+    )
+
+
+async def _action_escalate(
+    db: AsyncSession,
+    incident: Any,
+    incident_id: uuid.UUID,
+    actor_id: uuid.UUID,
+    params: dict[str, Any],
+) -> SmartResponseOutcome:
+    """Escalate the incident: set status to 'escalated' + add note."""
+    reason = params.get("reason", "Escalated via smart response").strip()
+
+    # Update status
+    await incident_service.update_incident(
+        db, incident, {"status": "escalated"}, actor_id=actor_id
+    )
+
+    # Add escalation note
+    await incident_service.add_note(
+        db, incident_id, actor_id,
+        f"[Escalated] {reason}",
+    )
+    await db.commit()
+
+    logger.info("Incident %s escalated by %s: %s", incident_id, actor_id, reason)
+    return SmartResponseOutcome(
+        success=True,
+        action="escalate",
+        detail=f"Incident escalated: {reason}",
+    )

--- a/server/services/syslog_exporter.py
+++ b/server/services/syslog_exporter.py
@@ -1,0 +1,244 @@
+"""Syslog exporter — CEF format over UDP/TCP/TLS (P8-T4).
+
+Exports DLP incidents as CEF (Common Event Format) messages to a
+syslog server. Supports three transport protocols:
+  - UDP (default, fire-and-forget)
+  - TCP (reliable delivery)
+  - TLS (encrypted, requires cert verification)
+
+CEF format: CEF:0|AkesoDLP|DLP|1.0|<sig_id>|<name>|<severity>|<extension>
+
+Severity mapping (CEF 0-10 scale):
+  critical=10, high=8, medium=5, low=3, info=1
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+import ssl
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from server.services.report_generator import IncidentRecord
+
+logger = logging.getLogger(__name__)
+
+
+class SyslogTransport(str, Enum):
+    UDP = "udp"
+    TCP = "tcp"
+    TLS = "tls"
+
+
+# CEF severity mapping (0–10 scale)
+CEF_SEVERITY: dict[str, int] = {
+    "critical": 10,
+    "high": 8,
+    "medium": 5,
+    "low": 3,
+    "info": 1,
+}
+
+# CEF signature IDs
+CEF_SIG_IDS: dict[str, int] = {
+    "block": 100,
+    "notify": 200,
+    "log": 300,
+    "quarantine": 400,
+    "user_cancel": 500,
+}
+
+
+@dataclass
+class SyslogConfig:
+    """Syslog export configuration."""
+
+    host: str = "localhost"
+    port: int = 514
+    transport: SyslogTransport = SyslogTransport.UDP
+    min_severity: str = "info"  # Minimum severity to export
+    facility: int = 13  # log-audit
+    ca_cert: str | None = None  # Path to CA cert for TLS
+    timeout: float = 5.0
+
+
+def format_cef(incident: IncidentRecord) -> str:
+    """Format an incident as a CEF message.
+
+    CEF format:
+    CEF:0|Vendor|Product|Version|SignatureID|Name|Severity|Extensions
+
+    Args:
+        incident: The incident to format.
+
+    Returns:
+        CEF formatted string.
+    """
+    sig_id = CEF_SIG_IDS.get(incident.action_taken, 999)
+    severity = CEF_SEVERITY.get(incident.severity, 1)
+    name = _cef_escape(f"DLP {incident.action_taken}: {incident.policy_name}")
+
+    # Extension key-value pairs
+    extensions = {
+        "act": incident.action_taken,
+        "cat": incident.channel,
+        "cs1": incident.policy_name,
+        "cs1Label": "PolicyName",
+        "cs2": incident.source_type,
+        "cs2Label": "SourceType",
+        "cn1": str(incident.match_count),
+        "cn1Label": "MatchCount",
+        "sev": incident.severity,
+        "outcome": incident.status,
+    }
+
+    if incident.user:
+        extensions["suser"] = incident.user
+    if incident.file_name:
+        extensions["fname"] = incident.file_name
+    if isinstance(incident.created_at, datetime):
+        extensions["rt"] = str(int(incident.created_at.timestamp() * 1000))
+
+    ext_str = " ".join(
+        f"{k}={_cef_escape(str(v))}" for k, v in extensions.items()
+    )
+
+    return f"CEF:0|AkesoDLP|DLP|1.0|{sig_id}|{name}|{severity}|{ext_str}"
+
+
+def _cef_escape(value: str) -> str:
+    """Escape special CEF characters."""
+    return (
+        value
+        .replace("\\", "\\\\")
+        .replace("|", "\\|")
+        .replace("=", "\\=")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+    )
+
+
+def _severity_passes_filter(severity: str, min_severity: str) -> bool:
+    """Check if a severity meets the minimum threshold."""
+    order = ["info", "low", "medium", "high", "critical"]
+    try:
+        return order.index(severity) >= order.index(min_severity)
+    except ValueError:
+        return True  # Unknown severity passes
+
+
+class SyslogExporter:
+    """Exports incidents to a syslog server.
+
+    Manages connection lifecycle and formats messages as CEF.
+    """
+
+    def __init__(self, config: SyslogConfig | None = None):
+        self.config = config or SyslogConfig()
+        self._socket: socket.socket | None = None
+
+    def send(self, incident: IncidentRecord) -> bool:
+        """Send a single incident to the syslog server.
+
+        Args:
+            incident: The incident to export.
+
+        Returns:
+            True if sent successfully, False otherwise.
+        """
+        if not _severity_passes_filter(incident.severity, self.config.min_severity):
+            return True  # Filtered out, not an error
+
+        cef = format_cef(incident)
+
+        # Syslog priority: facility * 8 + severity (using syslog severity levels)
+        syslog_severity = max(0, min(7, 7 - CEF_SEVERITY.get(incident.severity, 1)))
+        priority = self.config.facility * 8 + syslog_severity
+        message = f"<{priority}>{cef}"
+
+        try:
+            self._ensure_connection()
+            self._send_message(message)
+            return True
+        except Exception as e:
+            logger.error("Failed to send syslog message: %s", e)
+            self._close()
+            return False
+
+    def send_batch(self, incidents: list[IncidentRecord]) -> tuple[int, int]:
+        """Send multiple incidents.
+
+        Returns:
+            Tuple of (sent_count, failed_count).
+        """
+        sent = 0
+        failed = 0
+        for inc in incidents:
+            if self.send(inc):
+                sent += 1
+            else:
+                failed += 1
+        return sent, failed
+
+    def test_connection(self) -> tuple[bool, str]:
+        """Test connectivity to the syslog server.
+
+        Returns:
+            Tuple of (success, message).
+        """
+        try:
+            self._ensure_connection()
+            test_msg = f"<{self.config.facility * 8 + 6}>CEF:0|AkesoDLP|DLP|1.0|0|Connection Test|0|msg=test"
+            self._send_message(test_msg)
+            self._close()
+            return True, f"Successfully connected to {self.config.host}:{self.config.port} via {self.config.transport.value}"
+        except Exception as e:
+            return False, f"Connection failed: {e}"
+
+    def _ensure_connection(self) -> None:
+        """Create socket connection if not already connected."""
+        if self._socket is not None:
+            return
+
+        if self.config.transport == SyslogTransport.UDP:
+            self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            self._socket.settimeout(self.config.timeout)
+        elif self.config.transport == SyslogTransport.TCP:
+            self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._socket.settimeout(self.config.timeout)
+            self._socket.connect((self.config.host, self.config.port))
+        elif self.config.transport == SyslogTransport.TLS:
+            raw = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            raw.settimeout(self.config.timeout)
+            ctx = ssl.create_default_context()
+            if self.config.ca_cert:
+                ctx.load_verify_locations(self.config.ca_cert)
+            self._socket = ctx.wrap_socket(raw, server_hostname=self.config.host)
+            self._socket.connect((self.config.host, self.config.port))
+
+    def _send_message(self, message: str) -> None:
+        """Send a formatted syslog message."""
+        data = message.encode("utf-8")
+
+        if self.config.transport == SyslogTransport.UDP:
+            assert self._socket is not None
+            self._socket.sendto(data, (self.config.host, self.config.port))
+        else:
+            assert self._socket is not None
+            # TCP/TLS: length-prefix framing (RFC 5425)
+            self._socket.sendall(f"{len(data)} ".encode() + data)
+
+    def _close(self) -> None:
+        """Close the socket connection."""
+        if self._socket:
+            try:
+                self._socket.close()
+            except Exception:
+                pass
+            self._socket = None
+
+    def __del__(self):
+        self._close()

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,553 @@
+"""Tests for P8 — reporting, risk scoring, syslog, and SIEM (T1–T5).
+
+Coverage:
+  Report Generator (T1) — 14 tests
+  Report Exporter (T2) — 10 tests
+  Risk Calculator (T3) — 12 tests
+  Syslog Exporter (T4) — 10 tests
+  SIEM Emitter (T5) — 10 tests
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from server.services.report_generator import (
+    AggregationBucket,
+    DetailReport,
+    IncidentRecord,
+    SummaryReport,
+    TrendDelta,
+    TrendReport,
+    generate_detail,
+    generate_summary,
+    generate_trend,
+)
+from server.services.report_exporter import (
+    export_detail_csv,
+    export_summary_csv,
+    export_trend_csv,
+    export_detail_pdf,
+    export_summary_pdf,
+)
+from server.services.risk_calculator import (
+    DECAY_FACTOR,
+    SEVERITY_WEIGHTS,
+    UserRiskScore,
+    calculate_user_risk,
+    get_risk_level,
+)
+from server.services.syslog_exporter import (
+    CEF_SEVERITY,
+    SyslogConfig,
+    SyslogExporter,
+    SyslogTransport,
+    format_cef,
+    _cef_escape,
+    _severity_passes_filter,
+)
+from server.services.siem_emitter import (
+    DLPEventType,
+    SIEMConfig,
+    SIEMEmitter,
+    build_ecs_event,
+    build_status_event,
+)
+
+
+# --- Fixtures ---
+
+NOW = datetime(2026, 3, 20, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_incidents(specs: list[tuple[str, str, str, int]]) -> list[IncidentRecord]:
+    """Create incidents from (severity, policy, channel, days_ago) tuples."""
+    incidents = []
+    for i, (sev, policy, channel, days_ago) in enumerate(specs):
+        incidents.append(IncidentRecord(
+            id=f"inc-{i}",
+            policy_name=policy,
+            severity=sev,
+            status="new",
+            channel=channel,
+            source_type="endpoint",
+            user=f"user{i % 3}",
+            file_name=f"file{i}.docx",
+            action_taken="log",
+            match_count=i + 1,
+            created_at=NOW - timedelta(days=days_ago),
+        ))
+    return incidents
+
+
+SAMPLE_INCIDENTS = _make_incidents([
+    ("high", "PII Policy", "email", 0),
+    ("high", "PII Policy", "http_upload", 1),
+    ("medium", "Financial Data", "email", 2),
+    ("high", "PII Policy", "usb", 5),
+    ("low", "Source Code", "clipboard", 10),
+    ("critical", "M&A Docs", "email", 0),
+    ("medium", "Financial Data", "http_upload", 15),
+    ("info", "Audit Policy", "network_share", 20),
+    ("high", "PII Policy", "email", 25),
+    ("low", "Source Code", "usb", 30),
+])
+
+
+# ============================================================
+# Report Generator (T1)
+# ============================================================
+
+
+class TestReportGenerator:
+    def test_summary_total(self):
+        """Summary counts all incidents in range."""
+        report = generate_summary(SAMPLE_INCIDENTS, NOW - timedelta(days=31), NOW)
+        assert report.total_incidents == 10
+
+    def test_summary_by_severity(self):
+        """Severity aggregation is correct."""
+        report = generate_summary(SAMPLE_INCIDENTS, NOW - timedelta(days=31), NOW)
+        sev_counts = {b.key: b.count for b in report.by_severity}
+        assert sev_counts["high"] == 4
+        assert sev_counts["medium"] == 2
+        assert sev_counts["critical"] == 1
+
+    def test_summary_by_policy(self):
+        """Policy aggregation is correct."""
+        report = generate_summary(SAMPLE_INCIDENTS, NOW - timedelta(days=31), NOW)
+        pol_counts = {b.key: b.count for b in report.by_policy}
+        assert pol_counts["PII Policy"] == 4
+
+    def test_summary_by_channel(self):
+        """Channel aggregation is correct."""
+        report = generate_summary(SAMPLE_INCIDENTS, NOW - timedelta(days=31), NOW)
+        ch_counts = {b.key: b.count for b in report.by_channel}
+        assert ch_counts["email"] == 4
+
+    def test_summary_percentages(self):
+        """Percentages are calculated correctly."""
+        report = generate_summary(SAMPLE_INCIDENTS, NOW - timedelta(days=31), NOW)
+        for bucket in report.by_severity:
+            expected = round((bucket.count / 10) * 100, 1)
+            assert bucket.percentage == expected
+
+    def test_summary_date_filter(self):
+        """Only includes incidents within the date range."""
+        report = generate_summary(SAMPLE_INCIDENTS, NOW - timedelta(days=3), NOW)
+        assert report.total_incidents == 4  # 0, 1, 2 days ago + critical at 0
+
+    def test_summary_empty_range(self):
+        """Empty date range returns zero counts."""
+        report = generate_summary(
+            SAMPLE_INCIDENTS,
+            NOW + timedelta(days=100),
+            NOW + timedelta(days=200),
+        )
+        assert report.total_incidents == 0
+        assert report.by_severity == []
+
+    def test_detail_report(self):
+        """Detail report includes all incidents sorted by date."""
+        report = generate_detail(SAMPLE_INCIDENTS, NOW - timedelta(days=31), NOW)
+        assert report.total_incidents == 10
+        # Should be sorted newest first
+        for i in range(len(report.incidents) - 1):
+            assert report.incidents[i].created_at >= report.incidents[i + 1].created_at
+
+    def test_detail_date_filter(self):
+        """Detail report respects date range."""
+        report = generate_detail(SAMPLE_INCIDENTS, NOW - timedelta(days=5), NOW)
+        assert all(
+            inc.created_at >= NOW - timedelta(days=5) for inc in report.incidents
+        )
+
+    def test_trend_comparison(self):
+        """Trend report compares two periods correctly."""
+        trend = generate_trend(SAMPLE_INCIDENTS, NOW - timedelta(days=15), NOW)
+        assert trend.current_period.total_incidents > 0
+        assert isinstance(trend.deltas, list)
+        assert len(trend.deltas) >= 1  # At least total_incidents delta
+
+    def test_trend_delta_positive(self):
+        """Positive delta when current > previous."""
+        delta = TrendDelta(
+            metric="test", current_value=10, previous_value=5, delta=5, delta_percent=100.0
+        )
+        assert delta.delta > 0
+        assert delta.delta_percent > 0
+
+    def test_trend_delta_negative(self):
+        """Negative delta when current < previous."""
+        delta = TrendDelta(
+            metric="test", current_value=3, previous_value=10, delta=-7, delta_percent=-70.0
+        )
+        assert delta.delta < 0
+
+    def test_trend_previous_period_auto(self):
+        """Previous period is auto-calculated as equal length before current."""
+        trend = generate_trend(SAMPLE_INCIDENTS, NOW - timedelta(days=15), NOW)
+        current_len = trend.current_period.end_date - trend.current_period.start_date
+        prev_len = trend.previous_period.end_date - trend.previous_period.start_date
+        assert abs(current_len.total_seconds() - prev_len.total_seconds()) < 2
+
+    def test_summary_top_users(self):
+        """Top users aggregation works."""
+        report = generate_summary(SAMPLE_INCIDENTS, NOW - timedelta(days=31), NOW)
+        assert len(report.top_users) > 0
+        assert all(isinstance(b.key, str) for b in report.top_users)
+
+
+# ============================================================
+# Report Exporter (T2)
+# ============================================================
+
+
+class TestReportExporter:
+    def test_detail_csv_headers(self):
+        """Detail CSV has correct headers."""
+        report = generate_detail(SAMPLE_INCIDENTS, NOW - timedelta(days=31), NOW)
+        csv_str = export_detail_csv(report)
+        # Skip BOM
+        reader = csv.reader(io.StringIO(csv_str.lstrip("\ufeff")))
+        headers = next(reader)
+        assert "ID" in headers
+        assert "Policy" in headers
+        assert "Severity" in headers
+
+    def test_detail_csv_row_count(self):
+        """Detail CSV has one row per incident plus header."""
+        report = generate_detail(SAMPLE_INCIDENTS, NOW - timedelta(days=31), NOW)
+        csv_str = export_detail_csv(report)
+        lines = csv_str.strip().split("\n")
+        assert len(lines) == 11  # 1 header + 10 incidents
+
+    def test_detail_csv_bom(self):
+        """Detail CSV starts with UTF-8 BOM for Excel."""
+        report = generate_detail(SAMPLE_INCIDENTS, NOW - timedelta(days=31), NOW)
+        csv_str = export_detail_csv(report)
+        assert csv_str.startswith("\ufeff")
+
+    def test_summary_csv_sections(self):
+        """Summary CSV contains all aggregation sections."""
+        report = generate_summary(SAMPLE_INCIDENTS, NOW - timedelta(days=31), NOW)
+        csv_str = export_summary_csv(report)
+        assert "By Severity" in csv_str
+        assert "By Policy" in csv_str
+        assert "By Channel" in csv_str
+        assert "By Status" in csv_str
+
+    def test_summary_csv_total(self):
+        """Summary CSV shows correct total."""
+        report = generate_summary(SAMPLE_INCIDENTS, NOW - timedelta(days=31), NOW)
+        csv_str = export_summary_csv(report)
+        assert "10" in csv_str  # total incidents
+
+    def test_trend_csv(self):
+        """Trend CSV contains period comparison."""
+        trend = generate_trend(SAMPLE_INCIDENTS, NOW - timedelta(days=15), NOW)
+        csv_str = export_trend_csv(trend)
+        assert "Trend Report" in csv_str
+        assert "Current Period" in csv_str
+        assert "Previous Period" in csv_str
+        assert "Delta" in csv_str
+
+    def test_detail_pdf_returns_bytes(self):
+        """Detail PDF export returns bytes."""
+        report = generate_detail(SAMPLE_INCIDENTS, NOW - timedelta(days=31), NOW)
+        pdf = export_detail_pdf(report)
+        assert isinstance(pdf, bytes)
+        assert len(pdf) > 0
+
+    def test_summary_pdf_returns_bytes(self):
+        """Summary PDF export returns bytes."""
+        report = generate_summary(SAMPLE_INCIDENTS, NOW - timedelta(days=31), NOW)
+        pdf = export_summary_pdf(report)
+        assert isinstance(pdf, bytes)
+        assert len(pdf) > 0
+
+    def test_detail_pdf_starts_with_pdf_header(self):
+        """PDF output starts with %PDF marker."""
+        report = generate_detail(SAMPLE_INCIDENTS, NOW - timedelta(days=31), NOW)
+        pdf = export_detail_pdf(report)
+        assert pdf[:5] == b"%PDF-"
+
+    def test_empty_report_csv(self):
+        """Empty report produces valid CSV with just headers."""
+        report = generate_detail([], NOW - timedelta(days=31), NOW)
+        csv_str = export_detail_csv(report)
+        lines = csv_str.strip().split("\n")
+        assert len(lines) == 1  # Just header
+
+
+# ============================================================
+# Risk Calculator (T3)
+# ============================================================
+
+
+class TestRiskCalculator:
+    def test_high_risk_recent(self):
+        """5 high incidents this week → score > 80."""
+        incidents = _make_incidents([
+            ("high", "Policy", "email", 0),
+            ("high", "Policy", "email", 1),
+            ("high", "Policy", "email", 2),
+            ("high", "Policy", "email", 3),
+            ("high", "Policy", "email", 4),
+        ])
+        # All same user
+        for inc in incidents:
+            inc.user = "risky_user"
+
+        report = calculate_user_risk(incidents, reference_time=NOW)
+        risky = next(s for s in report.scores if s.user == "risky_user")
+        assert risky.normalized_score > 80, f"Expected >80, got {risky.normalized_score}"
+
+    def test_low_risk_old(self):
+        """1 low incident 60 days ago → score < 10."""
+        incidents = [IncidentRecord(
+            id="old-1",
+            policy_name="Policy",
+            severity="low",
+            status="resolved",
+            channel="email",
+            source_type="endpoint",
+            user="safe_user",
+            match_count=1,
+            created_at=NOW - timedelta(days=60),
+        )]
+
+        report = calculate_user_risk(incidents, reference_time=NOW)
+        safe = next(s for s in report.scores if s.user == "safe_user")
+        assert safe.normalized_score < 10, f"Expected <10, got {safe.normalized_score}"
+
+    def test_ranking_correct(self):
+        """Users are ranked by score descending."""
+        report = calculate_user_risk(SAMPLE_INCIDENTS, reference_time=NOW)
+        for i in range(len(report.scores) - 1):
+            assert report.scores[i].normalized_score >= report.scores[i + 1].normalized_score
+
+    def test_decay_reduces_score(self):
+        """Older incidents contribute less than recent ones."""
+        recent = [IncidentRecord(
+            id="r1", policy_name="P", severity="high", status="new",
+            channel="email", source_type="endpoint", user="user_a",
+            match_count=1, created_at=NOW,
+        )]
+        old = [IncidentRecord(
+            id="o1", policy_name="P", severity="high", status="new",
+            channel="email", source_type="endpoint", user="user_b",
+            match_count=1, created_at=NOW - timedelta(days=30),
+        )]
+
+        report_recent = calculate_user_risk(recent, reference_time=NOW)
+        report_old = calculate_user_risk(old, reference_time=NOW)
+
+        assert report_recent.scores[0].raw_score > report_old.scores[0].raw_score
+
+    def test_severity_weights(self):
+        """Higher severity incidents contribute more to score."""
+        critical = [IncidentRecord(
+            id="c1", policy_name="P", severity="critical", status="new",
+            channel="email", source_type="endpoint", user="user_c",
+            match_count=1, created_at=NOW,
+        )]
+        info = [IncidentRecord(
+            id="i1", policy_name="P", severity="info", status="new",
+            channel="email", source_type="endpoint", user="user_i",
+            match_count=1, created_at=NOW,
+        )]
+
+        report_c = calculate_user_risk(critical, reference_time=NOW)
+        report_i = calculate_user_risk(info, reference_time=NOW)
+
+        assert report_c.scores[0].raw_score > report_i.scores[0].raw_score
+
+    def test_score_capped_at_100(self):
+        """Score never exceeds 100."""
+        many = _make_incidents([("critical", "P", "email", 0)] * 50)
+        for inc in many:
+            inc.user = "mega_risky"
+
+        report = calculate_user_risk(many, reference_time=NOW)
+        assert report.scores[0].normalized_score <= 100
+
+    def test_empty_incidents(self):
+        """No incidents produces empty report."""
+        report = calculate_user_risk([], reference_time=NOW)
+        assert len(report.scores) == 0
+
+    def test_severity_breakdown(self):
+        """Score includes severity breakdown counts."""
+        report = calculate_user_risk(SAMPLE_INCIDENTS, reference_time=NOW)
+        for score in report.scores:
+            total = sum(score.severity_breakdown.values())
+            assert total == score.incident_count
+
+    def test_risk_level_critical(self):
+        assert get_risk_level(90) == "critical"
+
+    def test_risk_level_high(self):
+        assert get_risk_level(65) == "high"
+
+    def test_risk_level_low(self):
+        assert get_risk_level(25) == "low"
+
+    def test_risk_level_minimal(self):
+        assert get_risk_level(5) == "minimal"
+
+
+# ============================================================
+# Syslog Exporter (T4)
+# ============================================================
+
+
+class TestSyslogExporter:
+    def test_cef_format(self):
+        """CEF message has correct structure."""
+        inc = SAMPLE_INCIDENTS[0]
+        cef = format_cef(inc)
+        assert cef.startswith("CEF:0|AkesoDLP|DLP|1.0|")
+        assert "PolicyName" in cef
+        assert "PII Policy" in cef
+
+    def test_cef_severity_mapping(self):
+        """CEF severity is correctly mapped."""
+        assert CEF_SEVERITY["critical"] == 10
+        assert CEF_SEVERITY["high"] == 8
+        assert CEF_SEVERITY["info"] == 1
+
+    def test_cef_escape_pipe(self):
+        """Pipe characters are escaped in CEF."""
+        assert _cef_escape("test|value") == "test\\|value"
+
+    def test_cef_escape_equals(self):
+        """Equals signs are escaped in CEF extensions."""
+        assert _cef_escape("key=val") == "key\\=val"
+
+    def test_cef_escape_backslash(self):
+        """Backslashes are escaped."""
+        assert _cef_escape("path\\file") == "path\\\\file"
+
+    def test_severity_filter_passes(self):
+        """High severity passes medium filter."""
+        assert _severity_passes_filter("high", "medium") is True
+
+    def test_severity_filter_blocks(self):
+        """Low severity blocked by high filter."""
+        assert _severity_passes_filter("low", "high") is False
+
+    def test_severity_filter_equal(self):
+        """Equal severity passes."""
+        assert _severity_passes_filter("medium", "medium") is True
+
+    def test_syslog_config_defaults(self):
+        """Default config is reasonable."""
+        cfg = SyslogConfig()
+        assert cfg.host == "localhost"
+        assert cfg.port == 514
+        assert cfg.transport == SyslogTransport.UDP
+
+    @patch("socket.socket")
+    def test_send_udp(self, mock_socket_cls):
+        """Send via UDP calls sendto."""
+        mock_sock = MagicMock()
+        mock_socket_cls.return_value = mock_sock
+
+        config = SyslogConfig(transport=SyslogTransport.UDP)
+        exporter = SyslogExporter(config)
+        result = exporter.send(SAMPLE_INCIDENTS[0])
+
+        assert result is True
+        mock_sock.sendto.assert_called_once()
+
+
+# ============================================================
+# SIEM Emitter (T5)
+# ============================================================
+
+
+class TestSIEMEmitter:
+    def test_ecs_event_structure(self):
+        """ECS event has required top-level fields."""
+        event = build_ecs_event(SAMPLE_INCIDENTS[0])
+        assert event["source_type"] == "akeso_dlp"
+        assert event["event_type"] == "dlp:policy_violation"
+        assert "@timestamp" in event
+        assert "event" in event
+        assert "dlp" in event
+        assert "observer" in event
+
+    def test_ecs_dlp_fields(self):
+        """DLP-specific fields are present."""
+        event = build_ecs_event(SAMPLE_INCIDENTS[0])
+        assert event["dlp"]["policy"]["name"] == "PII Policy"
+        assert event["dlp"]["classification"] == "high"
+        assert event["dlp"]["channel"] == "email"
+
+    def test_ecs_event_types(self):
+        """All 5 event types are defined."""
+        assert len(DLPEventType) == 5
+        assert DLPEventType.POLICY_VIOLATION.value == "dlp:policy_violation"
+        assert DLPEventType.FILE_BLOCKED.value == "dlp:file_blocked"
+
+    def test_ecs_user_field(self):
+        """User field is included when present."""
+        event = build_ecs_event(SAMPLE_INCIDENTS[0])
+        assert "user" in event
+        assert event["user"]["name"] == "user0"
+
+    def test_ecs_file_field(self):
+        """File field is included when present."""
+        event = build_ecs_event(SAMPLE_INCIDENTS[0])
+        assert "file" in event
+        assert event["file"]["name"] == "file0.docx"
+
+    def test_ecs_no_user(self):
+        """No user field when user is None."""
+        inc = IncidentRecord(
+            id="test", policy_name="P", severity="low", status="new",
+            channel="email", source_type="endpoint", user=None,
+            match_count=1, created_at=NOW,
+        )
+        event = build_ecs_event(inc)
+        assert "user" not in event
+
+    def test_status_event(self):
+        """Agent status event has correct structure."""
+        event = build_status_event("agent-1", "workstation-01", "online")
+        assert event["source_type"] == "akeso_dlp"
+        assert event["event_type"] == "dlp:agent_status"
+        assert event["agent"]["id"] == "agent-1"
+        assert event["dlp"]["agent_status"] == "online"
+
+    def test_siem_config_defaults(self):
+        """Default SIEM config is reasonable."""
+        cfg = SIEMConfig()
+        assert cfg.enabled is True
+        assert cfg.batch_size == 100
+
+    @pytest.mark.asyncio
+    async def test_emit_disabled(self):
+        """Disabled emitter returns True without sending."""
+        config = SIEMConfig(enabled=False)
+        emitter = SIEMEmitter(config)
+        event = build_ecs_event(SAMPLE_INCIDENTS[0])
+        result = await emitter.emit(event)
+        assert result is True
+        await emitter.close()
+
+    @pytest.mark.asyncio
+    async def test_emit_batch_counts(self):
+        """Batch emit returns correct counts."""
+        config = SIEMConfig(enabled=False)
+        emitter = SIEMEmitter(config)
+        sent, failed = await emitter.emit_batch(SAMPLE_INCIDENTS[:3])
+        assert sent == 3
+        assert failed == 0
+        await emitter.close()

--- a/tests/test_smart_response.py
+++ b/tests/test_smart_response.py
@@ -1,0 +1,242 @@
+"""Tests for smart response service (P8-T6) and reports API (P8-T7)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from server.services.smart_response import (
+    VALID_ACTIONS,
+    SmartResponseOutcome,
+    execute,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _mock_incident(status="new", severity="high"):
+    """Create a mock incident object."""
+    inc = MagicMock()
+    inc.id = uuid.uuid4()
+    inc.status = MagicMock(value=status)
+    inc.severity = MagicMock(value=severity)
+    inc.policy_name = "Test Policy"
+    return inc
+
+
+def _mock_db():
+    """Create a mock async DB session."""
+    db = AsyncMock()
+    db.commit = AsyncMock()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Action validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidActions:
+    def test_valid_actions_set(self):
+        assert VALID_ACTIONS == {"add_note", "set_status", "send_email", "escalate"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_fails(self):
+        db = _mock_db()
+        result = await execute(db, uuid.uuid4(), uuid.uuid4(), "unknown_action")
+        assert not result.success
+        assert "Unknown action" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_incident_not_found(self):
+        db = _mock_db()
+        with patch("server.services.smart_response.incident_service") as mock_svc:
+            mock_svc.get_incident = AsyncMock(return_value=None)
+            result = await execute(db, uuid.uuid4(), uuid.uuid4(), "add_note", {"content": "test"})
+        assert not result.success
+        assert "not found" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# Add note action
+# ---------------------------------------------------------------------------
+
+
+class TestAddNote:
+    @pytest.mark.asyncio
+    async def test_add_note_success(self):
+        db = _mock_db()
+        inc = _mock_incident()
+        with patch("server.services.smart_response.incident_service") as mock_svc:
+            mock_svc.get_incident = AsyncMock(return_value=inc)
+            mock_svc.add_note = AsyncMock()
+            result = await execute(db, inc.id, uuid.uuid4(), "add_note", {"content": "Test note"})
+        assert result.success
+        assert result.action == "add_note"
+        assert "Note added" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_add_note_empty_content(self):
+        db = _mock_db()
+        inc = _mock_incident()
+        with patch("server.services.smart_response.incident_service") as mock_svc:
+            mock_svc.get_incident = AsyncMock(return_value=inc)
+            result = await execute(db, inc.id, uuid.uuid4(), "add_note", {"content": ""})
+        assert not result.success
+        assert "required" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_add_note_no_params(self):
+        db = _mock_db()
+        inc = _mock_incident()
+        with patch("server.services.smart_response.incident_service") as mock_svc:
+            mock_svc.get_incident = AsyncMock(return_value=inc)
+            result = await execute(db, inc.id, uuid.uuid4(), "add_note")
+        assert not result.success
+
+
+# ---------------------------------------------------------------------------
+# Set status action
+# ---------------------------------------------------------------------------
+
+
+class TestSetStatus:
+    @pytest.mark.asyncio
+    async def test_set_status_success(self):
+        db = _mock_db()
+        inc = _mock_incident()
+        with patch("server.services.smart_response.incident_service") as mock_svc:
+            mock_svc.get_incident = AsyncMock(return_value=inc)
+            mock_svc.update_incident = AsyncMock(return_value=inc)
+            result = await execute(db, inc.id, uuid.uuid4(), "set_status", {"status": "resolved"})
+        assert result.success
+        assert "resolved" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_set_status_invalid(self):
+        db = _mock_db()
+        inc = _mock_incident()
+        with patch("server.services.smart_response.incident_service") as mock_svc:
+            mock_svc.get_incident = AsyncMock(return_value=inc)
+            result = await execute(db, inc.id, uuid.uuid4(), "set_status", {"status": "invalid"})
+        assert not result.success
+        assert "Invalid status" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_set_status_empty(self):
+        db = _mock_db()
+        inc = _mock_incident()
+        with patch("server.services.smart_response.incident_service") as mock_svc:
+            mock_svc.get_incident = AsyncMock(return_value=inc)
+            result = await execute(db, inc.id, uuid.uuid4(), "set_status", {"status": ""})
+        assert not result.success
+
+
+# ---------------------------------------------------------------------------
+# Send email action
+# ---------------------------------------------------------------------------
+
+
+class TestSendEmail:
+    @pytest.mark.asyncio
+    async def test_send_email_success(self):
+        db = _mock_db()
+        inc = _mock_incident()
+        with patch("server.services.smart_response.incident_service") as mock_svc:
+            mock_svc.get_incident = AsyncMock(return_value=inc)
+            mock_svc.add_note = AsyncMock()
+            result = await execute(
+                db, inc.id, uuid.uuid4(), "send_email",
+                {"recipient": "admin@example.com", "subject": "Incident Alert"},
+            )
+        assert result.success
+        assert "admin@example.com" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_send_email_no_recipient(self):
+        db = _mock_db()
+        inc = _mock_incident()
+        with patch("server.services.smart_response.incident_service") as mock_svc:
+            mock_svc.get_incident = AsyncMock(return_value=inc)
+            result = await execute(db, inc.id, uuid.uuid4(), "send_email", {})
+        assert not result.success
+        assert "required" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# Escalate action
+# ---------------------------------------------------------------------------
+
+
+class TestEscalate:
+    @pytest.mark.asyncio
+    async def test_escalate_success(self):
+        db = _mock_db()
+        inc = _mock_incident()
+        with patch("server.services.smart_response.incident_service") as mock_svc:
+            mock_svc.get_incident = AsyncMock(return_value=inc)
+            mock_svc.update_incident = AsyncMock(return_value=inc)
+            mock_svc.add_note = AsyncMock()
+            result = await execute(
+                db, inc.id, uuid.uuid4(), "escalate",
+                {"reason": "Critical data exposure"},
+            )
+        assert result.success
+        assert "escalated" in result.detail.lower()
+        # Verify status was set to escalated
+        mock_svc.update_incident.assert_called_once()
+        call_args = mock_svc.update_incident.call_args
+        assert call_args[0][2] == {"status": "escalated"}
+
+    @pytest.mark.asyncio
+    async def test_escalate_default_reason(self):
+        db = _mock_db()
+        inc = _mock_incident()
+        with patch("server.services.smart_response.incident_service") as mock_svc:
+            mock_svc.get_incident = AsyncMock(return_value=inc)
+            mock_svc.update_incident = AsyncMock(return_value=inc)
+            mock_svc.add_note = AsyncMock()
+            result = await execute(db, inc.id, uuid.uuid4(), "escalate")
+        assert result.success
+        assert "smart response" in result.detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# Outcome dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestOutcome:
+    def test_outcome_success(self):
+        o = SmartResponseOutcome(success=True, action="test", detail="ok")
+        assert o.success
+        assert o.action == "test"
+
+    def test_outcome_default_detail(self):
+        o = SmartResponseOutcome(success=False, action="test")
+        assert o.detail is None
+
+
+# ---------------------------------------------------------------------------
+# Reports API router registration
+# ---------------------------------------------------------------------------
+
+
+class TestReportsRouter:
+    def test_reports_router_registered(self):
+        from server.main import app
+        paths = [r.path for r in app.routes if hasattr(r, "path")]
+        assert "/api/reports/summary" in paths
+        assert "/api/reports/detail" in paths
+        assert "/api/reports/risk" in paths
+
+    def test_smart_response_endpoint_registered(self):
+        from server.main import app
+        paths = [r.path for r in app.routes if hasattr(r, "path")]
+        assert "/api/incidents/{incident_id}/respond" in paths


### PR DESCRIPTION
## Summary
- **P8-T1**: Report generator — summary aggregation (by severity/policy/channel/status/source/user), detail listing, and trend comparison with auto-calculated previous period
- **P8-T2**: Report exporter — CSV with UTF-8 BOM for Excel compatibility, PDF via reportlab with minimal text-based fallback
- **P8-T3**: User risk scoring — severity weights (critical=15, high=10, medium=5, low=2, info=1), exponential decay (0.95^days), normalized 1–100 scale
- **P8-T4**: Syslog exporter — CEF format (Common Event Format) over UDP/TCP/TLS with configurable severity filter
- **P8-T5**: SIEM emitter — ECS-formatted events via HTTP POST to AkesoSIEM with API key auth and batch support
- **P8-T6**: Smart response — 4 actions (add note, set status, send email stub, escalate) with `POST /api/incidents/{id}/respond` endpoint
- **P8-T7**: Console pages — Reports page (summary/detail/trend with CSV export) and User Risk page (score table with lookback selector)
- Graceful gRPC startup fallback when port is busy
- Test data seed script (`python -m server.scripts.seed_incidents`)
- 73 new tests (56 reporting + 17 smart response)

## Test plan
- [x] `pytest tests/test_reporting.py` — 56 tests pass
- [x] `pytest tests/test_smart_response.py` — 17 tests pass
- [x] Console TypeScript compiles without errors
- [x] Manual verification: Reports page generates summary/detail/trend, CSV downloads with auth
- [x] Manual verification: User Risk page loads scores, lookback selector updates data
- [x] Manual verification: Smart Response actions execute from incident snapshot page
- [x] Seed script populates 57 realistic incidents across 8 users

🤖 Generated with [Claude Code](https://claude.com/claude-code)